### PR TITLE
partial 1988 data from openelections-sources-wv/1988 kanawha county

### DIFF
--- a/1988/19881108__wv__general__kanawha__precinct.csv
+++ b/1988/19881108__wv__general__kanawha__precinct.csv
@@ -1,0 +1,1660 @@
+county,precinct,office,district,candidate,party,votes
+Kanawha,103,PRESIDENT,1,George H.W. Bush,REP,72
+Kanawha,104,PRESIDENT,1,George H.W. Bush,REP,36
+Kanawha,105,PRESIDENT,1,George H.W. Bush,REP,100
+Kanawha,106,PRESIDENT,1,George H.W. Bush,REP,64
+Kanawha,108,PRESIDENT,1,George H.W. Bush,REP,27
+Kanawha,109,PRESIDENT,1,George H.W. Bush,REP,62
+Kanawha,110,PRESIDENT,1,George H.W. Bush,REP,96
+Kanawha,111,PRESIDENT,1,George H.W. Bush,REP,106
+Kanawha,112,PRESIDENT,1,George H.W. Bush,REP,132
+Kanawha,113,PRESIDENT,1,George H.W. Bush,REP,117
+Kanawha,114,PRESIDENT,1,George H.W. Bush,REP,231
+Kanawha,115,PRESIDENT,1,George H.W. Bush,REP,96
+Kanawha,116,PRESIDENT,1,George H.W. Bush,REP,31
+Kanawha,117,PRESIDENT,1,George H.W. Bush,REP,153
+Kanawha,118,PRESIDENT,1,George H.W. Bush,REP,123
+Kanawha,119,PRESIDENT,1,George H.W. Bush,REP,147
+Kanawha,120,PRESIDENT,1,George H.W. Bush,REP,129
+Kanawha,122,PRESIDENT,1,George H.W. Bush,REP,56
+Kanawha,123,PRESIDENT,1,George H.W. Bush,REP,97
+Kanawha,131,PRESIDENT,1,George H.W. Bush,REP,55
+Kanawha,132,PRESIDENT,1,George H.W. Bush,REP,3
+Kanawha,133,PRESIDENT,1,George H.W. Bush,REP,28
+Kanawha,134,PRESIDENT,1,George H.W. Bush,REP,119
+Kanawha,136,PRESIDENT,1,George H.W. Bush,REP,77
+Kanawha,138,PRESIDENT,1,George H.W. Bush,REP,142
+Kanawha,140,PRESIDENT,1,George H.W. Bush,REP,19
+Kanawha,142,PRESIDENT,1,George H.W. Bush,REP,47
+Kanawha,145,PRESIDENT,1,George H.W. Bush,REP,48
+Kanawha,146,PRESIDENT,1,George H.W. Bush,REP,75
+Kanawha,147,PRESIDENT,1,George H.W. Bush,REP,96
+Kanawha,148,PRESIDENT,1,George H.W. Bush,REP,67
+Kanawha,149,PRESIDENT,1,George H.W. Bush,REP,81
+Kanawha,150,PRESIDENT,1,George H.W. Bush,REP,64
+Kanawha,151,PRESIDENT,1,George H.W. Bush,REP,28
+Kanawha,152,PRESIDENT,1,George H.W. Bush,REP,74
+Kanawha,153,PRESIDENT,1,George H.W. Bush,REP,120
+Kanawha,154,PRESIDENT,1,George H.W. Bush,REP,83
+Kanawha,158,PRESIDENT,1,George H.W. Bush,REP,66
+Kanawha,202,PRESIDENT,2,George H.W. Bush,REP,172
+Kanawha,205,PRESIDENT,2,George H.W. Bush,REP,229
+Kanawha,206,PRESIDENT,2,George H.W. Bush,REP,169
+Kanawha,207,PRESIDENT,2,George H.W. Bush,REP,195
+Kanawha,208,PRESIDENT,2,George H.W. Bush,REP,390
+Kanawha,209,PRESIDENT,2,George H.W. Bush,REP,164
+Kanawha,213,PRESIDENT,2,George H.W. Bush,REP,119
+Kanawha,217,PRESIDENT,2,George H.W. Bush,REP,132
+Kanawha,218,PRESIDENT,2,George H.W. Bush,REP,41
+Kanawha,222,PRESIDENT,2,George H.W. Bush,REP,135
+Kanawha,223,PRESIDENT,2,George H.W. Bush,REP,157
+Kanawha,224,PRESIDENT,2,George H.W. Bush,REP,176
+Kanawha,226,PRESIDENT,2,George H.W. Bush,REP,279
+Kanawha,227,PRESIDENT,2,George H.W. Bush,REP,229
+Kanawha,228,PRESIDENT,2,George H.W. Bush,REP,192
+Kanawha,232,PRESIDENT,2,George H.W. Bush,REP,93
+Kanawha,233,PRESIDENT,2,George H.W. Bush,REP,277
+Kanawha,234,PRESIDENT,2,George H.W. Bush,REP,215
+Kanawha,235,PRESIDENT,2,George H.W. Bush,REP,233
+Kanawha,238,PRESIDENT,2,George H.W. Bush,REP,289
+Kanawha,239,PRESIDENT,2,George H.W. Bush,REP,420
+Kanawha,240,PRESIDENT,2,George H.W. Bush,REP,310
+Kanawha,241,PRESIDENT,2,George H.W. Bush,REP,158
+Kanawha,244,PRESIDENT,2,George H.W. Bush,REP,215
+Kanawha,245,PRESIDENT,2,George H.W. Bush,REP,186
+Kanawha,246,PRESIDENT,2,George H.W. Bush,REP,300
+Kanawha,247,PRESIDENT,2,George H.W. Bush,REP,214
+Kanawha,250,PRESIDENT,2,George H.W. Bush,REP,284
+Kanawha,252,PRESIDENT,2,George H.W. Bush,REP,321
+Kanawha,253,PRESIDENT,2,George H.W. Bush,REP,239
+Kanawha,254,PRESIDENT,2,George H.W. Bush,REP,354
+Kanawha,257,PRESIDENT,2,George H.W. Bush,REP,205
+Kanawha,258,PRESIDENT,2,George H.W. Bush,REP,178
+Kanawha,259,PRESIDENT,2,George H.W. Bush,REP,104
+Kanawha,260,PRESIDENT,2,George H.W. Bush,REP,80
+Kanawha,263,PRESIDENT,2,George H.W. Bush,REP,263
+Kanawha,264,PRESIDENT,2,George H.W. Bush,REP,256
+Kanawha,265,PRESIDENT,2,George H.W. Bush,REP,237
+Kanawha,266,PRESIDENT,2,George H.W. Bush,REP,193
+Kanawha,269,PRESIDENT,2,George H.W. Bush,REP,164
+Kanawha,270,PRESIDENT,2,George H.W. Bush,REP,131
+Kanawha,271,PRESIDENT,2,George H.W. Bush,REP,130
+Kanawha,272,PRESIDENT,2,George H.W. Bush,REP,123
+Kanawha,275,PRESIDENT,2,George H.W. Bush,REP,71
+Kanawha,276,PRESIDENT,2,George H.W. Bush,REP,111
+Kanawha,277,PRESIDENT,2,George H.W. Bush,REP,417
+Kanawha,301,PRESIDENT,3,George H.W. Bush,REP,112
+Kanawha,302,PRESIDENT,3,George H.W. Bush,REP,144
+Kanawha,304,PRESIDENT,3,George H.W. Bush,REP,154
+Kanawha,305,PRESIDENT,3,George H.W. Bush,REP,121
+Kanawha,306,PRESIDENT,3,George H.W. Bush,REP,107
+Kanawha,307,PRESIDENT,3,George H.W. Bush,REP,270
+Kanawha,308,PRESIDENT,3,George H.W. Bush,REP,119
+Kanawha,309,PRESIDENT,3,George H.W. Bush,REP,196
+Kanawha,310,PRESIDENT,3,George H.W. Bush,REP,378
+Kanawha,311,PRESIDENT,3,George H.W. Bush,REP,236
+Kanawha,312,PRESIDENT,3,George H.W. Bush,REP,72
+Kanawha,313,PRESIDENT,3,George H.W. Bush,REP,55
+Kanawha,314,PRESIDENT,3,George H.W. Bush,REP,128
+Kanawha,317,PRESIDENT,3,George H.W. Bush,REP,92
+Kanawha,318,PRESIDENT,3,George H.W. Bush,REP,111
+Kanawha,321,PRESIDENT,3,George H.W. Bush,REP,184
+Kanawha,322,PRESIDENT,3,George H.W. Bush,REP,203
+Kanawha,325,PRESIDENT,3,George H.W. Bush,REP,104
+Kanawha,326,PRESIDENT,3,George H.W. Bush,REP,249
+Kanawha,329,PRESIDENT,3,George H.W. Bush,REP,163
+Kanawha,330,PRESIDENT,3,George H.W. Bush,REP,89
+Kanawha,332,PRESIDENT,3,George H.W. Bush,REP,151
+Kanawha,333,PRESIDENT,3,George H.W. Bush,REP,168
+Kanawha,336,PRESIDENT,3,George H.W. Bush,REP,105
+Kanawha,337,PRESIDENT,3,George H.W. Bush,REP,182
+Kanawha,340,PRESIDENT,3,George H.W. Bush,REP,150
+Kanawha,341,PRESIDENT,3,George H.W. Bush,REP,99
+Kanawha,344,PRESIDENT,3,George H.W. Bush,REP,232
+Kanawha,345,PRESIDENT,3,George H.W. Bush,REP,111
+Kanawha,347,PRESIDENT,3,George H.W. Bush,REP,232
+Kanawha,348,PRESIDENT,3,George H.W. Bush,REP,129
+Kanawha,350,PRESIDENT,3,George H.W. Bush,REP,223
+Kanawha,352,PRESIDENT,3,George H.W. Bush,REP,393
+Kanawha,353,PRESIDENT,3,George H.W. Bush,REP,197
+Kanawha,355,PRESIDENT,3,George H.W. Bush,REP,96
+Kanawha,356,PRESIDENT,3,George H.W. Bush,REP,106
+Kanawha,357,PRESIDENT,3,George H.W. Bush,REP,357
+Kanawha,360,PRESIDENT,3,George H.W. Bush,REP,109
+Kanawha,361,PRESIDENT,3,George H.W. Bush,REP,122
+Kanawha,375,PRESIDENT,3,George H.W. Bush,REP,218
+Kanawha,376,PRESIDENT,3,George H.W. Bush,REP,131
+Kanawha,378,PRESIDENT,3,George H.W. Bush,REP,234
+Kanawha,379,PRESIDENT,3,George H.W. Bush,REP,175
+Kanawha,401,PRESIDENT,4,George H.W. Bush,REP,176
+Kanawha,402,PRESIDENT,4,George H.W. Bush,REP,135
+Kanawha,403,PRESIDENT,4,George H.W. Bush,REP,164
+Kanawha,406,PRESIDENT,4,George H.W. Bush,REP,172
+Kanawha,408,PRESIDENT,4,George H.W. Bush,REP,176
+Kanawha,409,PRESIDENT,4,George H.W. Bush,REP,228
+Kanawha,411,PRESIDENT,4,George H.W. Bush,REP,101
+Kanawha,412,PRESIDENT,4,George H.W. Bush,REP,47
+Kanawha,414,PRESIDENT,4,George H.W. Bush,REP,48
+Kanawha,435,PRESIDENT,4,George H.W. Bush,REP,173
+Kanawha,436,PRESIDENT,4,George H.W. Bush,REP,275
+Kanawha,437,PRESIDENT,4,George H.W. Bush,REP,284
+Kanawha,438,PRESIDENT,4,George H.W. Bush,REP,383
+Kanawha,439,PRESIDENT,4,George H.W. Bush,REP,189
+Kanawha,440,PRESIDENT,4,George H.W. Bush,REP,155
+Kanawha,441,PRESIDENT,4,George H.W. Bush,REP,148
+Kanawha,442,PRESIDENT,4,George H.W. Bush,REP,200
+Kanawha,444,PRESIDENT,4,George H.W. Bush,REP,125
+Kanawha,446,PRESIDENT,4,George H.W. Bush,REP,217
+Kanawha,447,PRESIDENT,4,George H.W. Bush,REP,186
+Kanawha,448,PRESIDENT,4,George H.W. Bush,REP,148
+Kanawha,449,PRESIDENT,4,George H.W. Bush,REP,142
+Kanawha,450,PRESIDENT,4,George H.W. Bush,REP,109
+Kanawha,453,PRESIDENT,4,George H.W. Bush,REP,183
+Kanawha,454,PRESIDENT,4,George H.W. Bush,REP,180
+Kanawha,455,PRESIDENT,4,George H.W. Bush,REP,151
+Kanawha,459,PRESIDENT,4,George H.W. Bush,REP,200
+Kanawha,462,PRESIDENT,4,George H.W. Bush,REP,171
+Kanawha,463,PRESIDENT,4,George H.W. Bush,REP,232
+Kanawha,464,PRESIDENT,4,George H.W. Bush,REP,267
+Kanawha,465,PRESIDENT,4,George H.W. Bush,REP,110
+Kanawha,466,PRESIDENT,4,George H.W. Bush,REP,269
+Kanawha,468,PRESIDENT,4,George H.W. Bush,REP,343
+Kanawha,469,PRESIDENT,4,George H.W. Bush,REP,137
+Kanawha,501,PRESIDENT,5,George H.W. Bush,REP,121
+Kanawha,502,PRESIDENT,5,George H.W. Bush,REP,153
+Kanawha,503,PRESIDENT,5,George H.W. Bush,REP,90
+Kanawha,504,PRESIDENT,5,George H.W. Bush,REP,71
+Kanawha,508,PRESIDENT,5,George H.W. Bush,REP,223
+Kanawha,509,PRESIDENT,5,George H.W. Bush,REP,97
+Kanawha,510,PRESIDENT,5,George H.W. Bush,REP,154
+Kanawha,513,PRESIDENT,5,George H.W. Bush,REP,102
+Kanawha,514,PRESIDENT,5,George H.W. Bush,REP,20
+Kanawha,515,PRESIDENT,5,George H.W. Bush,REP,114
+Kanawha,518,PRESIDENT,5,George H.W. Bush,REP,146
+Kanawha,520,PRESIDENT,5,George H.W. Bush,REP,26
+Kanawha,522,PRESIDENT,5,George H.W. Bush,REP,41
+Kanawha,526,PRESIDENT,5,George H.W. Bush,REP,194
+Kanawha,527,PRESIDENT,5,George H.W. Bush,REP,244
+Kanawha,528,PRESIDENT,5,George H.W. Bush,REP,184
+Kanawha,529,PRESIDENT,5,George H.W. Bush,REP,202
+Kanawha,532,PRESIDENT,5,George H.W. Bush,REP,150
+Kanawha,533,PRESIDENT,5,George H.W. Bush,REP,188
+Kanawha,535,PRESIDENT,5,George H.W. Bush,REP,115
+Kanawha,540,PRESIDENT,5,George H.W. Bush,REP,151
+Kanawha,541,PRESIDENT,5,George H.W. Bush,REP,171
+Kanawha,542,PRESIDENT,5,George H.W. Bush,REP,216
+Kanawha,546,PRESIDENT,5,George H.W. Bush,REP,87
+Kanawha,547,PRESIDENT,5,George H.W. Bush,REP,185
+Kanawha,549,PRESIDENT,5,George H.W. Bush,REP,182
+Kanawha,550,PRESIDENT,5,George H.W. Bush,REP,78
+Kanawha,553,PRESIDENT,5,George H.W. Bush,REP,60
+Kanawha,554,PRESIDENT,5,George H.W. Bush,REP,42
+Kanawha,556,PRESIDENT,5,George H.W. Bush,REP,126
+Kanawha,560,PRESIDENT,5,George H.W. Bush,REP,116
+Kanawha,561,PRESIDENT,5,George H.W. Bush,REP,84
+Kanawha,562,PRESIDENT,5,George H.W. Bush,REP,60
+Kanawha,565,PRESIDENT,5,George H.W. Bush,REP,104
+Kanawha,566,PRESIDENT,5,George H.W. Bush,REP,125
+Kanawha,567,PRESIDENT,5,George H.W. Bush,REP,183
+Kanawha,568,PRESIDENT,5,George H.W. Bush,REP,111
+Kanawha,571,PRESIDENT,5,George H.W. Bush,REP,205
+Kanawha,572,PRESIDENT,5,George H.W. Bush,REP,26
+Kanawha,573,PRESIDENT,5,George H.W. Bush,REP,340
+Kanawha,574,PRESIDENT,5,George H.W. Bush,REP,113
+Kanawha,601,PRESIDENT,6,George H.W. Bush,REP,86
+Kanawha,602,PRESIDENT,6,George H.W. Bush,REP,157
+Kanawha,603,PRESIDENT,6,George H.W. Bush,REP,92
+Kanawha,606,PRESIDENT,6,George H.W. Bush,REP,205
+Kanawha,607,PRESIDENT,6,George H.W. Bush,REP,231
+Kanawha,608,PRESIDENT,6,George H.W. Bush,REP,136
+Kanawha,611,PRESIDENT,6,George H.W. Bush,REP,189
+Kanawha,612,PRESIDENT,6,George H.W. Bush,REP,173
+Kanawha,614,PRESIDENT,6,George H.W. Bush,REP,121
+Kanawha,616,PRESIDENT,6,George H.W. Bush,REP,166
+Kanawha,617,PRESIDENT,6,George H.W. Bush,REP,241
+Kanawha,620,PRESIDENT,6,George H.W. Bush,REP,288
+Kanawha,621,PRESIDENT,6,George H.W. Bush,REP,241
+Kanawha,624,PRESIDENT,6,George H.W. Bush,REP,160
+Kanawha,625,PRESIDENT,6,George H.W. Bush,REP,135
+Kanawha,626,PRESIDENT,6,George H.W. Bush,REP,143
+Kanawha,628,PRESIDENT,6,George H.W. Bush,REP,142
+Kanawha,629,PRESIDENT,6,George H.W. Bush,REP,195
+Kanawha,630,PRESIDENT,6,George H.W. Bush,REP,173
+Kanawha,632,PRESIDENT,6,George H.W. Bush,REP,384
+Kanawha,633,PRESIDENT,6,George H.W. Bush,REP,211
+Kanawha,634,PRESIDENT,6,George H.W. Bush,REP,238
+Kanawha,636,PRESIDENT,6,George H.W. Bush,REP,215
+Kanawha,638,PRESIDENT,6,George H.W. Bush,REP,245
+Kanawha,641,PRESIDENT,6,George H.W. Bush,REP,83
+Kanawha,642,PRESIDENT,6,George H.W. Bush,REP,233
+Kanawha,644,PRESIDENT,6,George H.W. Bush,REP,210
+Kanawha,645,PRESIDENT,6,George H.W. Bush,REP,406
+Kanawha,648,PRESIDENT,6,George H.W. Bush,REP,191
+Kanawha,649,PRESIDENT,6,George H.W. Bush,REP,308
+Kanawha,650,PRESIDENT,6,George H.W. Bush,REP,135
+Kanawha,652,PRESIDENT,6,George H.W. Bush,REP,92
+Kanawha,653,PRESIDENT,6,George H.W. Bush,REP,121
+Kanawha,656,PRESIDENT,6,George H.W. Bush,REP,246
+Kanawha,Total,PRESIDENT,,George H.W. Bush,REP,38140
+Kanawha,103,PRESIDENT,1,Michael Dukakis,DEM,343
+Kanawha,104,PRESIDENT,1,Michael Dukakis,DEM,182
+Kanawha,105,PRESIDENT,1,Michael Dukakis,DEM,265
+Kanawha,106,PRESIDENT,1,Michael Dukakis,DEM,262
+Kanawha,108,PRESIDENT,1,Michael Dukakis,DEM,268
+Kanawha,109,PRESIDENT,1,Michael Dukakis,DEM,180
+Kanawha,110,PRESIDENT,1,Michael Dukakis,DEM,176
+Kanawha,111,PRESIDENT,1,Michael Dukakis,DEM,136
+Kanawha,112,PRESIDENT,1,Michael Dukakis,DEM,210
+Kanawha,113,PRESIDENT,1,Michael Dukakis,DEM,188
+Kanawha,114,PRESIDENT,1,Michael Dukakis,DEM,317
+Kanawha,115,PRESIDENT,1,Michael Dukakis,DEM,348
+Kanawha,116,PRESIDENT,1,Michael Dukakis,DEM,207
+Kanawha,117,PRESIDENT,1,Michael Dukakis,DEM,321
+Kanawha,118,PRESIDENT,1,Michael Dukakis,DEM,226
+Kanawha,119,PRESIDENT,1,Michael Dukakis,DEM,229
+Kanawha,120,PRESIDENT,1,Michael Dukakis,DEM,246
+Kanawha,122,PRESIDENT,1,Michael Dukakis,DEM,154
+Kanawha,123,PRESIDENT,1,Michael Dukakis,DEM,158
+Kanawha,131,PRESIDENT,1,Michael Dukakis,DEM,244
+Kanawha,132,PRESIDENT,1,Michael Dukakis,DEM,75
+Kanawha,133,PRESIDENT,1,Michael Dukakis,DEM,133
+Kanawha,134,PRESIDENT,1,Michael Dukakis,DEM,215
+Kanawha,136,PRESIDENT,1,Michael Dukakis,DEM,416
+Kanawha,138,PRESIDENT,1,Michael Dukakis,DEM,311
+Kanawha,140,PRESIDENT,1,Michael Dukakis,DEM,301
+Kanawha,142,PRESIDENT,1,Michael Dukakis,DEM,335
+Kanawha,145,PRESIDENT,1,Michael Dukakis,DEM,277
+Kanawha,146,PRESIDENT,1,Michael Dukakis,DEM,161
+Kanawha,147,PRESIDENT,1,Michael Dukakis,DEM,206
+Kanawha,148,PRESIDENT,1,Michael Dukakis,DEM,187
+Kanawha,149,PRESIDENT,1,Michael Dukakis,DEM,235
+Kanawha,150,PRESIDENT,1,Michael Dukakis,DEM,156
+Kanawha,151,PRESIDENT,1,Michael Dukakis,DEM,152
+Kanawha,152,PRESIDENT,1,Michael Dukakis,DEM,176
+Kanawha,153,PRESIDENT,1,Michael Dukakis,DEM,199
+Kanawha,154,PRESIDENT,1,Michael Dukakis,DEM,222
+Kanawha,158,PRESIDENT,1,Michael Dukakis,DEM,198
+Kanawha,202,PRESIDENT,2,Michael Dukakis,DEM,142
+Kanawha,205,PRESIDENT,2,Michael Dukakis,DEM,307
+Kanawha,206,PRESIDENT,2,Michael Dukakis,DEM,115
+Kanawha,207,PRESIDENT,2,Michael Dukakis,DEM,151
+Kanawha,208,PRESIDENT,2,Michael Dukakis,DEM,234
+Kanawha,209,PRESIDENT,2,Michael Dukakis,DEM,179
+Kanawha,213,PRESIDENT,2,Michael Dukakis,DEM,133
+Kanawha,217,PRESIDENT,2,Michael Dukakis,DEM,162
+Kanawha,218,PRESIDENT,2,Michael Dukakis,DEM,64
+Kanawha,222,PRESIDENT,2,Michael Dukakis,DEM,134
+Kanawha,223,PRESIDENT,2,Michael Dukakis,DEM,151
+Kanawha,224,PRESIDENT,2,Michael Dukakis,DEM,161
+Kanawha,226,PRESIDENT,2,Michael Dukakis,DEM,203
+Kanawha,227,PRESIDENT,2,Michael Dukakis,DEM,233
+Kanawha,228,PRESIDENT,2,Michael Dukakis,DEM,147
+Kanawha,232,PRESIDENT,2,Michael Dukakis,DEM,147
+Kanawha,233,PRESIDENT,2,Michael Dukakis,DEM,166
+Kanawha,234,PRESIDENT,2,Michael Dukakis,DEM,183
+Kanawha,235,PRESIDENT,2,Michael Dukakis,DEM,184
+Kanawha,238,PRESIDENT,2,Michael Dukakis,DEM,260
+Kanawha,239,PRESIDENT,2,Michael Dukakis,DEM,219
+Kanawha,240,PRESIDENT,2,Michael Dukakis,DEM,162
+Kanawha,241,PRESIDENT,2,Michael Dukakis,DEM,99
+Kanawha,244,PRESIDENT,2,Michael Dukakis,DEM,88
+Kanawha,245,PRESIDENT,2,Michael Dukakis,DEM,175
+Kanawha,246,PRESIDENT,2,Michael Dukakis,DEM,239
+Kanawha,247,PRESIDENT,2,Michael Dukakis,DEM,193
+Kanawha,250,PRESIDENT,2,Michael Dukakis,DEM,178
+Kanawha,252,PRESIDENT,2,Michael Dukakis,DEM,150
+Kanawha,253,PRESIDENT,2,Michael Dukakis,DEM,122
+Kanawha,254,PRESIDENT,2,Michael Dukakis,DEM,137
+Kanawha,257,PRESIDENT,2,Michael Dukakis,DEM,180
+Kanawha,258,PRESIDENT,2,Michael Dukakis,DEM,161
+Kanawha,259,PRESIDENT,2,Michael Dukakis,DEM,162
+Kanawha,260,PRESIDENT,2,Michael Dukakis,DEM,130
+Kanawha,263,PRESIDENT,2,Michael Dukakis,DEM,184
+Kanawha,264,PRESIDENT,2,Michael Dukakis,DEM,277
+Kanawha,265,PRESIDENT,2,Michael Dukakis,DEM,226
+Kanawha,266,PRESIDENT,2,Michael Dukakis,DEM,246
+Kanawha,269,PRESIDENT,2,Michael Dukakis,DEM,183
+Kanawha,270,PRESIDENT,2,Michael Dukakis,DEM,161
+Kanawha,271,PRESIDENT,2,Michael Dukakis,DEM,175
+Kanawha,272,PRESIDENT,2,Michael Dukakis,DEM,116
+Kanawha,275,PRESIDENT,2,Michael Dukakis,DEM,80
+Kanawha,276,PRESIDENT,2,Michael Dukakis,DEM,96
+Kanawha,277,PRESIDENT,2,Michael Dukakis,DEM,176
+Kanawha,301,PRESIDENT,3,Michael Dukakis,DEM,128
+Kanawha,302,PRESIDENT,3,Michael Dukakis,DEM,152
+Kanawha,304,PRESIDENT,3,Michael Dukakis,DEM,191
+Kanawha,305,PRESIDENT,3,Michael Dukakis,DEM,157
+Kanawha,306,PRESIDENT,3,Michael Dukakis,DEM,92
+Kanawha,307,PRESIDENT,3,Michael Dukakis,DEM,188
+Kanawha,308,PRESIDENT,3,Michael Dukakis,DEM,111
+Kanawha,309,PRESIDENT,3,Michael Dukakis,DEM,157
+Kanawha,310,PRESIDENT,3,Michael Dukakis,DEM,256
+Kanawha,311,PRESIDENT,3,Michael Dukakis,DEM,222
+Kanawha,312,PRESIDENT,3,Michael Dukakis,DEM,126
+Kanawha,313,PRESIDENT,3,Michael Dukakis,DEM,66
+Kanawha,314,PRESIDENT,3,Michael Dukakis,DEM,159
+Kanawha,317,PRESIDENT,3,Michael Dukakis,DEM,151
+Kanawha,318,PRESIDENT,3,Michael Dukakis,DEM,116
+Kanawha,321,PRESIDENT,3,Michael Dukakis,DEM,168
+Kanawha,322,PRESIDENT,3,Michael Dukakis,DEM,122
+Kanawha,325,PRESIDENT,3,Michael Dukakis,DEM,100
+Kanawha,326,PRESIDENT,3,Michael Dukakis,DEM,195
+Kanawha,329,PRESIDENT,3,Michael Dukakis,DEM,191
+Kanawha,330,PRESIDENT,3,Michael Dukakis,DEM,97
+Kanawha,332,PRESIDENT,3,Michael Dukakis,DEM,150
+Kanawha,333,PRESIDENT,3,Michael Dukakis,DEM,194
+Kanawha,336,PRESIDENT,3,Michael Dukakis,DEM,106
+Kanawha,337,PRESIDENT,3,Michael Dukakis,DEM,183
+Kanawha,340,PRESIDENT,3,Michael Dukakis,DEM,143
+Kanawha,341,PRESIDENT,3,Michael Dukakis,DEM,113
+Kanawha,344,PRESIDENT,3,Michael Dukakis,DEM,163
+Kanawha,345,PRESIDENT,3,Michael Dukakis,DEM,120
+Kanawha,347,PRESIDENT,3,Michael Dukakis,DEM,184
+Kanawha,348,PRESIDENT,3,Michael Dukakis,DEM,89
+Kanawha,350,PRESIDENT,3,Michael Dukakis,DEM,230
+Kanawha,352,PRESIDENT,3,Michael Dukakis,DEM,289
+Kanawha,353,PRESIDENT,3,Michael Dukakis,DEM,138
+Kanawha,355,PRESIDENT,3,Michael Dukakis,DEM,121
+Kanawha,356,PRESIDENT,3,Michael Dukakis,DEM,174
+Kanawha,357,PRESIDENT,3,Michael Dukakis,DEM,297
+Kanawha,360,PRESIDENT,3,Michael Dukakis,DEM,134
+Kanawha,361,PRESIDENT,3,Michael Dukakis,DEM,204
+Kanawha,375,PRESIDENT,3,Michael Dukakis,DEM,158
+Kanawha,376,PRESIDENT,3,Michael Dukakis,DEM,85
+Kanawha,378,PRESIDENT,3,Michael Dukakis,DEM,146
+Kanawha,379,PRESIDENT,3,Michael Dukakis,DEM,123
+Kanawha,401,PRESIDENT,4,Michael Dukakis,DEM,105
+Kanawha,402,PRESIDENT,4,Michael Dukakis,DEM,163
+Kanawha,403,PRESIDENT,4,Michael Dukakis,DEM,231
+Kanawha,406,PRESIDENT,4,Michael Dukakis,DEM,175
+Kanawha,408,PRESIDENT,4,Michael Dukakis,DEM,221
+Kanawha,409,PRESIDENT,4,Michael Dukakis,DEM,218
+Kanawha,411,PRESIDENT,4,Michael Dukakis,DEM,142
+Kanawha,412,PRESIDENT,4,Michael Dukakis,DEM,251
+Kanawha,414,PRESIDENT,4,Michael Dukakis,DEM,284
+Kanawha,435,PRESIDENT,4,Michael Dukakis,DEM,177
+Kanawha,436,PRESIDENT,4,Michael Dukakis,DEM,230
+Kanawha,437,PRESIDENT,4,Michael Dukakis,DEM,177
+Kanawha,438,PRESIDENT,4,Michael Dukakis,DEM,232
+Kanawha,439,PRESIDENT,4,Michael Dukakis,DEM,186
+Kanawha,440,PRESIDENT,4,Michael Dukakis,DEM,95
+Kanawha,441,PRESIDENT,4,Michael Dukakis,DEM,140
+Kanawha,442,PRESIDENT,4,Michael Dukakis,DEM,158
+Kanawha,444,PRESIDENT,4,Michael Dukakis,DEM,126
+Kanawha,446,PRESIDENT,4,Michael Dukakis,DEM,153
+Kanawha,447,PRESIDENT,4,Michael Dukakis,DEM,188
+Kanawha,448,PRESIDENT,4,Michael Dukakis,DEM,136
+Kanawha,449,PRESIDENT,4,Michael Dukakis,DEM,145
+Kanawha,450,PRESIDENT,4,Michael Dukakis,DEM,106
+Kanawha,453,PRESIDENT,4,Michael Dukakis,DEM,200
+Kanawha,454,PRESIDENT,4,Michael Dukakis,DEM,253
+Kanawha,455,PRESIDENT,4,Michael Dukakis,DEM,194
+Kanawha,459,PRESIDENT,4,Michael Dukakis,DEM,288
+Kanawha,462,PRESIDENT,4,Michael Dukakis,DEM,153
+Kanawha,463,PRESIDENT,4,Michael Dukakis,DEM,222
+Kanawha,464,PRESIDENT,4,Michael Dukakis,DEM,170
+Kanawha,465,PRESIDENT,4,Michael Dukakis,DEM,116
+Kanawha,466,PRESIDENT,4,Michael Dukakis,DEM,228
+Kanawha,468,PRESIDENT,4,Michael Dukakis,DEM,145
+Kanawha,469,PRESIDENT,4,Michael Dukakis,DEM,132
+Kanawha,501,PRESIDENT,5,Michael Dukakis,DEM,117
+Kanawha,502,PRESIDENT,5,Michael Dukakis,DEM,146
+Kanawha,503,PRESIDENT,5,Michael Dukakis,DEM,146
+Kanawha,504,PRESIDENT,5,Michael Dukakis,DEM,149
+Kanawha,508,PRESIDENT,5,Michael Dukakis,DEM,236
+Kanawha,509,PRESIDENT,5,Michael Dukakis,DEM,98
+Kanawha,510,PRESIDENT,5,Michael Dukakis,DEM,188
+Kanawha,513,PRESIDENT,5,Michael Dukakis,DEM,147
+Kanawha,514,PRESIDENT,5,Michael Dukakis,DEM,111
+Kanawha,515,PRESIDENT,5,Michael Dukakis,DEM,141
+Kanawha,518,PRESIDENT,5,Michael Dukakis,DEM,209
+Kanawha,520,PRESIDENT,5,Michael Dukakis,DEM,221
+Kanawha,522,PRESIDENT,5,Michael Dukakis,DEM,143
+Kanawha,526,PRESIDENT,5,Michael Dukakis,DEM,171
+Kanawha,527,PRESIDENT,5,Michael Dukakis,DEM,194
+Kanawha,528,PRESIDENT,5,Michael Dukakis,DEM,181
+Kanawha,529,PRESIDENT,5,Michael Dukakis,DEM,156
+Kanawha,532,PRESIDENT,5,Michael Dukakis,DEM,219
+Kanawha,533,PRESIDENT,5,Michael Dukakis,DEM,223
+Kanawha,535,PRESIDENT,5,Michael Dukakis,DEM,149
+Kanawha,540,PRESIDENT,5,Michael Dukakis,DEM,197
+Kanawha,541,PRESIDENT,5,Michael Dukakis,DEM,178
+Kanawha,542,PRESIDENT,5,Michael Dukakis,DEM,230
+Kanawha,546,PRESIDENT,5,Michael Dukakis,DEM,123
+Kanawha,547,PRESIDENT,5,Michael Dukakis,DEM,117
+Kanawha,549,PRESIDENT,5,Michael Dukakis,DEM,176
+Kanawha,550,PRESIDENT,5,Michael Dukakis,DEM,156
+Kanawha,553,PRESIDENT,5,Michael Dukakis,DEM,187
+Kanawha,554,PRESIDENT,5,Michael Dukakis,DEM,105
+Kanawha,556,PRESIDENT,5,Michael Dukakis,DEM,253
+Kanawha,560,PRESIDENT,5,Michael Dukakis,DEM,276
+Kanawha,561,PRESIDENT,5,Michael Dukakis,DEM,146
+Kanawha,562,PRESIDENT,5,Michael Dukakis,DEM,151
+Kanawha,565,PRESIDENT,5,Michael Dukakis,DEM,182
+Kanawha,566,PRESIDENT,5,Michael Dukakis,DEM,178
+Kanawha,567,PRESIDENT,5,Michael Dukakis,DEM,254
+Kanawha,568,PRESIDENT,5,Michael Dukakis,DEM,207
+Kanawha,571,PRESIDENT,5,Michael Dukakis,DEM,208
+Kanawha,572,PRESIDENT,5,Michael Dukakis,DEM,108
+Kanawha,573,PRESIDENT,5,Michael Dukakis,DEM,284
+Kanawha,574,PRESIDENT,5,Michael Dukakis,DEM,183
+Kanawha,601,PRESIDENT,6,Michael Dukakis,DEM,70
+Kanawha,602,PRESIDENT,6,Michael Dukakis,DEM,124
+Kanawha,603,PRESIDENT,6,Michael Dukakis,DEM,99
+Kanawha,606,PRESIDENT,6,Michael Dukakis,DEM,122
+Kanawha,607,PRESIDENT,6,Michael Dukakis,DEM,152
+Kanawha,608,PRESIDENT,6,Michael Dukakis,DEM,117
+Kanawha,611,PRESIDENT,6,Michael Dukakis,DEM,111
+Kanawha,612,PRESIDENT,6,Michael Dukakis,DEM,117
+Kanawha,614,PRESIDENT,6,Michael Dukakis,DEM,127
+Kanawha,616,PRESIDENT,6,Michael Dukakis,DEM,156
+Kanawha,617,PRESIDENT,6,Michael Dukakis,DEM,183
+Kanawha,620,PRESIDENT,6,Michael Dukakis,DEM,219
+Kanawha,621,PRESIDENT,6,Michael Dukakis,DEM,213
+Kanawha,624,PRESIDENT,6,Michael Dukakis,DEM,163
+Kanawha,625,PRESIDENT,6,Michael Dukakis,DEM,103
+Kanawha,626,PRESIDENT,6,Michael Dukakis,DEM,109
+Kanawha,628,PRESIDENT,6,Michael Dukakis,DEM,78
+Kanawha,629,PRESIDENT,6,Michael Dukakis,DEM,71
+Kanawha,630,PRESIDENT,6,Michael Dukakis,DEM,89
+Kanawha,632,PRESIDENT,6,Michael Dukakis,DEM,192
+Kanawha,633,PRESIDENT,6,Michael Dukakis,DEM,163
+Kanawha,634,PRESIDENT,6,Michael Dukakis,DEM,129
+Kanawha,636,PRESIDENT,6,Michael Dukakis,DEM,142
+Kanawha,638,PRESIDENT,6,Michael Dukakis,DEM,135
+Kanawha,641,PRESIDENT,6,Michael Dukakis,DEM,75
+Kanawha,642,PRESIDENT,6,Michael Dukakis,DEM,192
+Kanawha,644,PRESIDENT,6,Michael Dukakis,DEM,175
+Kanawha,645,PRESIDENT,6,Michael Dukakis,DEM,207
+Kanawha,648,PRESIDENT,6,Michael Dukakis,DEM,137
+Kanawha,649,PRESIDENT,6,Michael Dukakis,DEM,210
+Kanawha,650,PRESIDENT,6,Michael Dukakis,DEM,99
+Kanawha,652,PRESIDENT,6,Michael Dukakis,DEM,69
+Kanawha,653,PRESIDENT,6,Michael Dukakis,DEM,130
+Kanawha,656,PRESIDENT,6,Michael Dukakis,DEM,207
+Kanawha,Total,PRESIDENT,,Michael Dukakis,DEM,41144
+Kanawha,103,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,104,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,105,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,106,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,108,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,109,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,110,PRESIDENT,1,Lenora Fulani,NEW,3
+Kanawha,111,PRESIDENT,1,Lenora Fulani,NEW,2
+Kanawha,112,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,113,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,114,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,115,PRESIDENT,1,Lenora Fulani,NEW,3
+Kanawha,116,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,117,PRESIDENT,1,Lenora Fulani,NEW,2
+Kanawha,118,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,119,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,120,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,122,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,123,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,131,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,132,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,133,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,134,PRESIDENT,1,Lenora Fulani,NEW,3
+Kanawha,136,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,138,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,140,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,142,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,145,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,146,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,147,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,148,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,149,PRESIDENT,1,Lenora Fulani,NEW,3
+Kanawha,150,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,151,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,152,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,153,PRESIDENT,1,Lenora Fulani,NEW,1
+Kanawha,154,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,158,PRESIDENT,1,Lenora Fulani,NEW,0
+Kanawha,202,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,205,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,206,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,207,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,208,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,209,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,213,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,217,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,218,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,222,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,223,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,224,PRESIDENT,2,Lenora Fulani,NEW,3
+Kanawha,226,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,227,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,228,PRESIDENT,2,Lenora Fulani,NEW,4
+Kanawha,232,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,233,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,234,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,235,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,238,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,239,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,240,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,241,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,244,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,245,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,246,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,247,PRESIDENT,2,Lenora Fulani,NEW,4
+Kanawha,250,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,252,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,253,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,254,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,257,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,258,PRESIDENT,2,Lenora Fulani,NEW,3
+Kanawha,259,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,260,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,263,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,264,PRESIDENT,2,Lenora Fulani,NEW,2
+Kanawha,265,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,266,PRESIDENT,2,Lenora Fulani,NEW,3
+Kanawha,269,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,270,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,271,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,272,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,275,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,276,PRESIDENT,2,Lenora Fulani,NEW,0
+Kanawha,277,PRESIDENT,2,Lenora Fulani,NEW,1
+Kanawha,301,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,302,PRESIDENT,3,Lenora Fulani,NEW,2
+Kanawha,304,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,305,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,306,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,307,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,308,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,309,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,310,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,311,PRESIDENT,3,Lenora Fulani,NEW,3
+Kanawha,312,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,313,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,314,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,317,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,318,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,321,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,322,PRESIDENT,3,Lenora Fulani,NEW,2
+Kanawha,325,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,326,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,329,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,330,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,332,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,333,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,336,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,337,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,340,PRESIDENT,3,Lenora Fulani,NEW,4
+Kanawha,341,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,344,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,345,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,347,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,348,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,350,PRESIDENT,3,Lenora Fulani,NEW,2
+Kanawha,352,PRESIDENT,3,Lenora Fulani,NEW,2
+Kanawha,353,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,355,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,356,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,357,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,360,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,361,PRESIDENT,3,Lenora Fulani,NEW,1
+Kanawha,375,PRESIDENT,3,Lenora Fulani,NEW,2
+Kanawha,376,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,378,PRESIDENT,3,Lenora Fulani,NEW,0
+Kanawha,379,PRESIDENT,3,Lenora Fulani,NEW,3
+Kanawha,401,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,402,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,403,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,406,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,408,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,409,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,411,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,412,PRESIDENT,4,Lenora Fulani,NEW,5
+Kanawha,414,PRESIDENT,4,Lenora Fulani,NEW,4
+Kanawha,435,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,436,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,437,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,438,PRESIDENT,4,Lenora Fulani,NEW,3
+Kanawha,439,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,440,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,441,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,442,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,444,PRESIDENT,4,Lenora Fulani,NEW,3
+Kanawha,446,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,447,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,448,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,449,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,450,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,453,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,454,PRESIDENT,4,Lenora Fulani,NEW,3
+Kanawha,455,PRESIDENT,4,Lenora Fulani,NEW,2
+Kanawha,459,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,462,PRESIDENT,4,Lenora Fulani,NEW,2
+Kanawha,463,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,464,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,465,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,466,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,468,PRESIDENT,4,Lenora Fulani,NEW,0
+Kanawha,469,PRESIDENT,4,Lenora Fulani,NEW,1
+Kanawha,501,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,502,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,503,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,504,PRESIDENT,5,Lenora Fulani,NEW,4
+Kanawha,508,PRESIDENT,5,Lenora Fulani,NEW,3
+Kanawha,509,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,510,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,513,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,514,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,515,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,518,PRESIDENT,5,Lenora Fulani,NEW,7
+Kanawha,520,PRESIDENT,5,Lenora Fulani,NEW,5
+Kanawha,522,PRESIDENT,5,Lenora Fulani,NEW,3
+Kanawha,526,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,527,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,528,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,529,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,532,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,533,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,535,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,540,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,541,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,542,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,546,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,547,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,549,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,550,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,553,PRESIDENT,5,Lenora Fulani,NEW,5
+Kanawha,554,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,556,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,560,PRESIDENT,5,Lenora Fulani,NEW,4
+Kanawha,561,PRESIDENT,5,Lenora Fulani,NEW,3
+Kanawha,562,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,565,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,566,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,567,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,568,PRESIDENT,5,Lenora Fulani,NEW,2
+Kanawha,571,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,572,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,573,PRESIDENT,5,Lenora Fulani,NEW,1
+Kanawha,574,PRESIDENT,5,Lenora Fulani,NEW,0
+Kanawha,601,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,602,PRESIDENT,6,Lenora Fulani,NEW,2
+Kanawha,603,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,606,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,607,PRESIDENT,6,Lenora Fulani,NEW,4
+Kanawha,608,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,611,PRESIDENT,6,Lenora Fulani,NEW,3
+Kanawha,612,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,614,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,616,PRESIDENT,6,Lenora Fulani,NEW,2
+Kanawha,617,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,620,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,621,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,624,PRESIDENT,6,Lenora Fulani,NEW,3
+Kanawha,625,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,626,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,628,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,629,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,630,PRESIDENT,6,Lenora Fulani,NEW,2
+Kanawha,632,PRESIDENT,6,Lenora Fulani,NEW,2
+Kanawha,633,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,634,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,636,PRESIDENT,6,Lenora Fulani,NEW,3
+Kanawha,638,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,641,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,642,PRESIDENT,6,Lenora Fulani,NEW,2
+Kanawha,644,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,645,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,648,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,649,PRESIDENT,6,Lenora Fulani,NEW,4
+Kanawha,650,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,652,PRESIDENT,6,Lenora Fulani,NEW,1
+Kanawha,653,PRESIDENT,6,Lenora Fulani,NEW,0
+Kanawha,656,PRESIDENT,6,Lenora Fulani,NEW,3
+Kanawha,Total,PRESIDENT,,Lenora Fulani,NEW,258
+Kanawha,103,U.S. SENATE,1,Jay Wolfe,REP,48
+Kanawha,104,U.S. SENATE,1,Jay Wolfe,REP,21
+Kanawha,105,U.S. SENATE,1,Jay Wolfe,REP,73
+Kanawha,106,U.S. SENATE,1,Jay Wolfe,REP,44
+Kanawha,108,U.S. SENATE,1,Jay Wolfe,REP,31
+Kanawha,109,U.S. SENATE,1,Jay Wolfe,REP,49
+Kanawha,110,U.S. SENATE,1,Jay Wolfe,REP,81
+Kanawha,111,U.S. SENATE,1,Jay Wolfe,REP,84
+Kanawha,112,U.S. SENATE,1,Jay Wolfe,REP,105
+Kanawha,113,U.S. SENATE,1,Jay Wolfe,REP,93
+Kanawha,114,U.S. SENATE,1,Jay Wolfe,REP,165
+Kanawha,115,U.S. SENATE,1,Jay Wolfe,REP,79
+Kanawha,116,U.S. SENATE,1,Jay Wolfe,REP,42
+Kanawha,117,U.S. SENATE,1,Jay Wolfe,REP,101
+Kanawha,118,U.S. SENATE,1,Jay Wolfe,REP,100
+Kanawha,119,U.S. SENATE,1,Jay Wolfe,REP,142
+Kanawha,120,U.S. SENATE,1,Jay Wolfe,REP,114
+Kanawha,122,U.S. SENATE,1,Jay Wolfe,REP,48
+Kanawha,123,U.S. SENATE,1,Jay Wolfe,REP,88
+Kanawha,131,U.S. SENATE,1,Jay Wolfe,REP,57
+Kanawha,132,U.S. SENATE,1,Jay Wolfe,REP,5
+Kanawha,133,U.S. SENATE,1,Jay Wolfe,REP,25
+Kanawha,134,U.S. SENATE,1,Jay Wolfe,REP,96
+Kanawha,136,U.S. SENATE,1,Jay Wolfe,REP,64
+Kanawha,138,U.S. SENATE,1,Jay Wolfe,REP,117
+Kanawha,140,U.S. SENATE,1,Jay Wolfe,REP,25
+Kanawha,142,U.S. SENATE,1,Jay Wolfe,REP,37
+Kanawha,145,U.S. SENATE,1,Jay Wolfe,REP,40
+Kanawha,146,U.S. SENATE,1,Jay Wolfe,REP,52
+Kanawha,147,U.S. SENATE,1,Jay Wolfe,REP,74
+Kanawha,148,U.S. SENATE,1,Jay Wolfe,REP,54
+Kanawha,149,U.S. SENATE,1,Jay Wolfe,REP,64
+Kanawha,150,U.S. SENATE,1,Jay Wolfe,REP,48
+Kanawha,151,U.S. SENATE,1,Jay Wolfe,REP,29
+Kanawha,152,U.S. SENATE,1,Jay Wolfe,REP,53
+Kanawha,153,U.S. SENATE,1,Jay Wolfe,REP,92
+Kanawha,154,U.S. SENATE,1,Jay Wolfe,REP,78
+Kanawha,158,U.S. SENATE,1,Jay Wolfe,REP,62
+Kanawha,202,U.S. SENATE,2,Jay Wolfe,REP,125
+Kanawha,205,U.S. SENATE,2,Jay Wolfe,REP,178
+Kanawha,206,U.S. SENATE,2,Jay Wolfe,REP,136
+Kanawha,207,U.S. SENATE,2,Jay Wolfe,REP,145
+Kanawha,208,U.S. SENATE,2,Jay Wolfe,REP,254
+Kanawha,209,U.S. SENATE,2,Jay Wolfe,REP,135
+Kanawha,213,U.S. SENATE,2,Jay Wolfe,REP,88
+Kanawha,217,U.S. SENATE,2,Jay Wolfe,REP,112
+Kanawha,218,U.S. SENATE,2,Jay Wolfe,REP,30
+Kanawha,222,U.S. SENATE,2,Jay Wolfe,REP,102
+Kanawha,223,U.S. SENATE,2,Jay Wolfe,REP,111
+Kanawha,224,U.S. SENATE,2,Jay Wolfe,REP,132
+Kanawha,226,U.S. SENATE,2,Jay Wolfe,REP,176
+Kanawha,227,U.S. SENATE,2,Jay Wolfe,REP,170
+Kanawha,228,U.S. SENATE,2,Jay Wolfe,REP,142
+Kanawha,232,U.S. SENATE,2,Jay Wolfe,REP,69
+Kanawha,233,U.S. SENATE,2,Jay Wolfe,REP,188
+Kanawha,234,U.S. SENATE,2,Jay Wolfe,REP,160
+Kanawha,235,U.S. SENATE,2,Jay Wolfe,REP,165
+Kanawha,238,U.S. SENATE,2,Jay Wolfe,REP,190
+Kanawha,239,U.S. SENATE,2,Jay Wolfe,REP,278
+Kanawha,240,U.S. SENATE,2,Jay Wolfe,REP,184
+Kanawha,241,U.S. SENATE,2,Jay Wolfe,REP,96
+Kanawha,244,U.S. SENATE,2,Jay Wolfe,REP,114
+Kanawha,245,U.S. SENATE,2,Jay Wolfe,REP,97
+Kanawha,246,U.S. SENATE,2,Jay Wolfe,REP,213
+Kanawha,247,U.S. SENATE,2,Jay Wolfe,REP,147
+Kanawha,250,U.S. SENATE,2,Jay Wolfe,REP,176
+Kanawha,252,U.S. SENATE,2,Jay Wolfe,REP,213
+Kanawha,253,U.S. SENATE,2,Jay Wolfe,REP,157
+Kanawha,254,U.S. SENATE,2,Jay Wolfe,REP,199
+Kanawha,257,U.S. SENATE,2,Jay Wolfe,REP,142
+Kanawha,258,U.S. SENATE,2,Jay Wolfe,REP,127
+Kanawha,259,U.S. SENATE,2,Jay Wolfe,REP,71
+Kanawha,260,U.S. SENATE,2,Jay Wolfe,REP,71
+Kanawha,263,U.S. SENATE,2,Jay Wolfe,REP,182
+Kanawha,264,U.S. SENATE,2,Jay Wolfe,REP,188
+Kanawha,265,U.S. SENATE,2,Jay Wolfe,REP,179
+Kanawha,266,U.S. SENATE,2,Jay Wolfe,REP,146
+Kanawha,269,U.S. SENATE,2,Jay Wolfe,REP,128
+Kanawha,270,U.S. SENATE,2,Jay Wolfe,REP,88
+Kanawha,271,U.S. SENATE,2,Jay Wolfe,REP,87
+Kanawha,272,U.S. SENATE,2,Jay Wolfe,REP,92
+Kanawha,275,U.S. SENATE,2,Jay Wolfe,REP,39
+Kanawha,276,U.S. SENATE,2,Jay Wolfe,REP,86
+Kanawha,277,U.S. SENATE,2,Jay Wolfe,REP,269
+Kanawha,301,U.S. SENATE,3,Jay Wolfe,REP,91
+Kanawha,302,U.S. SENATE,3,Jay Wolfe,REP,110
+Kanawha,304,U.S. SENATE,3,Jay Wolfe,REP,137
+Kanawha,305,U.S. SENATE,3,Jay Wolfe,REP,89
+Kanawha,306,U.S. SENATE,3,Jay Wolfe,REP,78
+Kanawha,307,U.S. SENATE,3,Jay Wolfe,REP,215
+Kanawha,308,U.S. SENATE,3,Jay Wolfe,REP,91
+Kanawha,309,U.S. SENATE,3,Jay Wolfe,REP,164
+Kanawha,310,U.S. SENATE,3,Jay Wolfe,REP,280
+Kanawha,311,U.S. SENATE,3,Jay Wolfe,REP,208
+Kanawha,312,U.S. SENATE,3,Jay Wolfe,REP,64
+Kanawha,313,U.S. SENATE,3,Jay Wolfe,REP,46
+Kanawha,314,U.S. SENATE,3,Jay Wolfe,REP,107
+Kanawha,317,U.S. SENATE,3,Jay Wolfe,REP,76
+Kanawha,318,U.S. SENATE,3,Jay Wolfe,REP,102
+Kanawha,321,U.S. SENATE,3,Jay Wolfe,REP,144
+Kanawha,322,U.S. SENATE,3,Jay Wolfe,REP,151
+Kanawha,325,U.S. SENATE,3,Jay Wolfe,REP,85
+Kanawha,326,U.S. SENATE,3,Jay Wolfe,REP,204
+Kanawha,329,U.S. SENATE,3,Jay Wolfe,REP,152
+Kanawha,330,U.S. SENATE,3,Jay Wolfe,REP,74
+Kanawha,332,U.S. SENATE,3,Jay Wolfe,REP,128
+Kanawha,333,U.S. SENATE,3,Jay Wolfe,REP,153
+Kanawha,336,U.S. SENATE,3,Jay Wolfe,REP,86
+Kanawha,337,U.S. SENATE,3,Jay Wolfe,REP,156
+Kanawha,340,U.S. SENATE,3,Jay Wolfe,REP,136
+Kanawha,341,U.S. SENATE,3,Jay Wolfe,REP,79
+Kanawha,344,U.S. SENATE,3,Jay Wolfe,REP,168
+Kanawha,345,U.S. SENATE,3,Jay Wolfe,REP,98
+Kanawha,347,U.S. SENATE,3,Jay Wolfe,REP,184
+Kanawha,348,U.S. SENATE,3,Jay Wolfe,REP,100
+Kanawha,350,U.S. SENATE,3,Jay Wolfe,REP,178
+Kanawha,352,U.S. SENATE,3,Jay Wolfe,REP,264
+Kanawha,353,U.S. SENATE,3,Jay Wolfe,REP,129
+Kanawha,355,U.S. SENATE,3,Jay Wolfe,REP,77
+Kanawha,356,U.S. SENATE,3,Jay Wolfe,REP,81
+Kanawha,357,U.S. SENATE,3,Jay Wolfe,REP,274
+Kanawha,360,U.S. SENATE,3,Jay Wolfe,REP,84
+Kanawha,361,U.S. SENATE,3,Jay Wolfe,REP,105
+Kanawha,375,U.S. SENATE,3,Jay Wolfe,REP,160
+Kanawha,376,U.S. SENATE,3,Jay Wolfe,REP,94
+Kanawha,378,U.S. SENATE,3,Jay Wolfe,REP,162
+Kanawha,379,U.S. SENATE,3,Jay Wolfe,REP,151
+Kanawha,401,U.S. SENATE,4,Jay Wolfe,REP,146
+Kanawha,402,U.S. SENATE,4,Jay Wolfe,REP,118
+Kanawha,403,U.S. SENATE,4,Jay Wolfe,REP,134
+Kanawha,406,U.S. SENATE,4,Jay Wolfe,REP,139
+Kanawha,408,U.S. SENATE,4,Jay Wolfe,REP,147
+Kanawha,409,U.S. SENATE,4,Jay Wolfe,REP,190
+Kanawha,411,U.S. SENATE,4,Jay Wolfe,REP,90
+Kanawha,412,U.S. SENATE,4,Jay Wolfe,REP,66
+Kanawha,414,U.S. SENATE,4,Jay Wolfe,REP,56
+Kanawha,435,U.S. SENATE,4,Jay Wolfe,REP,141
+Kanawha,436,U.S. SENATE,4,Jay Wolfe,REP,218
+Kanawha,437,U.S. SENATE,4,Jay Wolfe,REP,220
+Kanawha,438,U.S. SENATE,4,Jay Wolfe,REP,296
+Kanawha,439,U.S. SENATE,4,Jay Wolfe,REP,169
+Kanawha,440,U.S. SENATE,4,Jay Wolfe,REP,115
+Kanawha,441,U.S. SENATE,4,Jay Wolfe,REP,119
+Kanawha,442,U.S. SENATE,4,Jay Wolfe,REP,172
+Kanawha,444,U.S. SENATE,4,Jay Wolfe,REP,99
+Kanawha,446,U.S. SENATE,4,Jay Wolfe,REP,181
+Kanawha,447,U.S. SENATE,4,Jay Wolfe,REP,144
+Kanawha,448,U.S. SENATE,4,Jay Wolfe,REP,122
+Kanawha,449,U.S. SENATE,4,Jay Wolfe,REP,103
+Kanawha,450,U.S. SENATE,4,Jay Wolfe,REP,90
+Kanawha,453,U.S. SENATE,4,Jay Wolfe,REP,144
+Kanawha,454,U.S. SENATE,4,Jay Wolfe,REP,142
+Kanawha,455,U.S. SENATE,4,Jay Wolfe,REP,121
+Kanawha,459,U.S. SENATE,4,Jay Wolfe,REP,161
+Kanawha,462,U.S. SENATE,4,Jay Wolfe,REP,112
+Kanawha,463,U.S. SENATE,4,Jay Wolfe,REP,197
+Kanawha,464,U.S. SENATE,4,Jay Wolfe,REP,189
+Kanawha,465,U.S. SENATE,4,Jay Wolfe,REP,84
+Kanawha,466,U.S. SENATE,4,Jay Wolfe,REP,221
+Kanawha,468,U.S. SENATE,4,Jay Wolfe,REP,259
+Kanawha,469,U.S. SENATE,4,Jay Wolfe,REP,111
+Kanawha,501,U.S. SENATE,5,Jay Wolfe,REP,92
+Kanawha,502,U.S. SENATE,5,Jay Wolfe,REP,119
+Kanawha,503,U.S. SENATE,5,Jay Wolfe,REP,77
+Kanawha,504,U.S. SENATE,5,Jay Wolfe,REP,60
+Kanawha,508,U.S. SENATE,5,Jay Wolfe,REP,179
+Kanawha,509,U.S. SENATE,5,Jay Wolfe,REP,83
+Kanawha,510,U.S. SENATE,5,Jay Wolfe,REP,127
+Kanawha,513,U.S. SENATE,5,Jay Wolfe,REP,89
+Kanawha,514,U.S. SENATE,5,Jay Wolfe,REP,26
+Kanawha,515,U.S. SENATE,5,Jay Wolfe,REP,101
+Kanawha,518,U.S. SENATE,5,Jay Wolfe,REP,119
+Kanawha,520,U.S. SENATE,5,Jay Wolfe,REP,29
+Kanawha,522,U.S. SENATE,5,Jay Wolfe,REP,38
+Kanawha,526,U.S. SENATE,5,Jay Wolfe,REP,153
+Kanawha,527,U.S. SENATE,5,Jay Wolfe,REP,175
+Kanawha,528,U.S. SENATE,5,Jay Wolfe,REP,127
+Kanawha,529,U.S. SENATE,5,Jay Wolfe,REP,146
+Kanawha,532,U.S. SENATE,5,Jay Wolfe,REP,114
+Kanawha,533,U.S. SENATE,5,Jay Wolfe,REP,163
+Kanawha,535,U.S. SENATE,5,Jay Wolfe,REP,107
+Kanawha,540,U.S. SENATE,5,Jay Wolfe,REP,124
+Kanawha,541,U.S. SENATE,5,Jay Wolfe,REP,135
+Kanawha,542,U.S. SENATE,5,Jay Wolfe,REP,173
+Kanawha,546,U.S. SENATE,5,Jay Wolfe,REP,73
+Kanawha,547,U.S. SENATE,5,Jay Wolfe,REP,152
+Kanawha,549,U.S. SENATE,5,Jay Wolfe,REP,153
+Kanawha,550,U.S. SENATE,5,Jay Wolfe,REP,70
+Kanawha,553,U.S. SENATE,5,Jay Wolfe,REP,68
+Kanawha,554,U.S. SENATE,5,Jay Wolfe,REP,36
+Kanawha,556,U.S. SENATE,5,Jay Wolfe,REP,112
+Kanawha,560,U.S. SENATE,5,Jay Wolfe,REP,112
+Kanawha,561,U.S. SENATE,5,Jay Wolfe,REP,68
+Kanawha,562,U.S. SENATE,5,Jay Wolfe,REP,47
+Kanawha,565,U.S. SENATE,5,Jay Wolfe,REP,83
+Kanawha,566,U.S. SENATE,5,Jay Wolfe,REP,85
+Kanawha,567,U.S. SENATE,5,Jay Wolfe,REP,139
+Kanawha,568,U.S. SENATE,5,Jay Wolfe,REP,81
+Kanawha,571,U.S. SENATE,5,Jay Wolfe,REP,154
+Kanawha,572,U.S. SENATE,5,Jay Wolfe,REP,33
+Kanawha,573,U.S. SENATE,5,Jay Wolfe,REP,275
+Kanawha,574,U.S. SENATE,5,Jay Wolfe,REP,87
+Kanawha,601,U.S. SENATE,6,Jay Wolfe,REP,69
+Kanawha,602,U.S. SENATE,6,Jay Wolfe,REP,115
+Kanawha,603,U.S. SENATE,6,Jay Wolfe,REP,74
+Kanawha,606,U.S. SENATE,6,Jay Wolfe,REP,155
+Kanawha,607,U.S. SENATE,6,Jay Wolfe,REP,182
+Kanawha,608,U.S. SENATE,6,Jay Wolfe,REP,99
+Kanawha,611,U.S. SENATE,6,Jay Wolfe,REP,153
+Kanawha,612,U.S. SENATE,6,Jay Wolfe,REP,148
+Kanawha,614,U.S. SENATE,6,Jay Wolfe,REP,94
+Kanawha,616,U.S. SENATE,6,Jay Wolfe,REP,134
+Kanawha,617,U.S. SENATE,6,Jay Wolfe,REP,198
+Kanawha,620,U.S. SENATE,6,Jay Wolfe,REP,209
+Kanawha,621,U.S. SENATE,6,Jay Wolfe,REP,178
+Kanawha,624,U.S. SENATE,6,Jay Wolfe,REP,134
+Kanawha,625,U.S. SENATE,6,Jay Wolfe,REP,120
+Kanawha,626,U.S. SENATE,6,Jay Wolfe,REP,111
+Kanawha,628,U.S. SENATE,6,Jay Wolfe,REP,119
+Kanawha,629,U.S. SENATE,6,Jay Wolfe,REP,145
+Kanawha,630,U.S. SENATE,6,Jay Wolfe,REP,142
+Kanawha,632,U.S. SENATE,6,Jay Wolfe,REP,314
+Kanawha,633,U.S. SENATE,6,Jay Wolfe,REP,186
+Kanawha,634,U.S. SENATE,6,Jay Wolfe,REP,193
+Kanawha,636,U.S. SENATE,6,Jay Wolfe,REP,168
+Kanawha,638,U.S. SENATE,6,Jay Wolfe,REP,204
+Kanawha,641,U.S. SENATE,6,Jay Wolfe,REP,67
+Kanawha,642,U.S. SENATE,6,Jay Wolfe,REP,187
+Kanawha,644,U.S. SENATE,6,Jay Wolfe,REP,166
+Kanawha,645,U.S. SENATE,6,Jay Wolfe,REP,297
+Kanawha,648,U.S. SENATE,6,Jay Wolfe,REP,174
+Kanawha,649,U.S. SENATE,6,Jay Wolfe,REP,250
+Kanawha,650,U.S. SENATE,6,Jay Wolfe,REP,105
+Kanawha,652,U.S. SENATE,6,Jay Wolfe,REP,56
+Kanawha,653,U.S. SENATE,6,Jay Wolfe,REP,113
+Kanawha,656,U.S. SENATE,6,Jay Wolfe,REP,203
+Kanawha,Total,U.S. SENATE,,Jay Wolfe,REP,29534
+Kanawha,103,U.S. SENATE,1,Robert Byrd,DEM,354
+Kanawha,104,U.S. SENATE,1,Robert Byrd,DEM,200
+Kanawha,105,U.S. SENATE,1,Robert Byrd,DEM,274
+Kanawha,106,U.S. SENATE,1,Robert Byrd,DEM,274
+Kanawha,108,U.S. SENATE,1,Robert Byrd,DEM,258
+Kanawha,109,U.S. SENATE,1,Robert Byrd,DEM,172
+Kanawha,110,U.S. SENATE,1,Robert Byrd,DEM,189
+Kanawha,111,U.S. SENATE,1,Robert Byrd,DEM,154
+Kanawha,112,U.S. SENATE,1,Robert Byrd,DEM,228
+Kanawha,113,U.S. SENATE,1,Robert Byrd,DEM,209
+Kanawha,114,U.S. SENATE,1,Robert Byrd,DEM,362
+Kanawha,115,U.S. SENATE,1,Robert Byrd,DEM,350
+Kanawha,116,U.S. SENATE,1,Robert Byrd,DEM,190
+Kanawha,117,U.S. SENATE,1,Robert Byrd,DEM,367
+Kanawha,118,U.S. SENATE,1,Robert Byrd,DEM,235
+Kanawha,119,U.S. SENATE,1,Robert Byrd,DEM,225
+Kanawha,120,U.S. SENATE,1,Robert Byrd,DEM,251
+Kanawha,122,U.S. SENATE,1,Robert Byrd,DEM,151
+Kanawha,123,U.S. SENATE,1,Robert Byrd,DEM,160
+Kanawha,131,U.S. SENATE,1,Robert Byrd,DEM,231
+Kanawha,132,U.S. SENATE,1,Robert Byrd,DEM,70
+Kanawha,133,U.S. SENATE,1,Robert Byrd,DEM,138
+Kanawha,134,U.S. SENATE,1,Robert Byrd,DEM,237
+Kanawha,136,U.S. SENATE,1,Robert Byrd,DEM,417
+Kanawha,138,U.S. SENATE,1,Robert Byrd,DEM,328
+Kanawha,140,U.S. SENATE,1,Robert Byrd,DEM,286
+Kanawha,142,U.S. SENATE,1,Robert Byrd,DEM,324
+Kanawha,145,U.S. SENATE,1,Robert Byrd,DEM,281
+Kanawha,146,U.S. SENATE,1,Robert Byrd,DEM,169
+Kanawha,147,U.S. SENATE,1,Robert Byrd,DEM,209
+Kanawha,148,U.S. SENATE,1,Robert Byrd,DEM,191
+Kanawha,149,U.S. SENATE,1,Robert Byrd,DEM,248
+Kanawha,150,U.S. SENATE,1,Robert Byrd,DEM,164
+Kanawha,151,U.S. SENATE,1,Robert Byrd,DEM,149
+Kanawha,152,U.S. SENATE,1,Robert Byrd,DEM,183
+Kanawha,153,U.S. SENATE,1,Robert Byrd,DEM,222
+Kanawha,154,U.S. SENATE,1,Robert Byrd,DEM,213
+Kanawha,158,U.S. SENATE,1,Robert Byrd,DEM,196
+Kanawha,202,U.S. SENATE,2,Robert Byrd,DEM,184
+Kanawha,205,U.S. SENATE,2,Robert Byrd,DEM,340
+Kanawha,206,U.S. SENATE,2,Robert Byrd,DEM,145
+Kanawha,207,U.S. SENATE,2,Robert Byrd,DEM,193
+Kanawha,208,U.S. SENATE,2,Robert Byrd,DEM,363
+Kanawha,209,U.S. SENATE,2,Robert Byrd,DEM,195
+Kanawha,213,U.S. SENATE,2,Robert Byrd,DEM,154
+Kanawha,217,U.S. SENATE,2,Robert Byrd,DEM,174
+Kanawha,218,U.S. SENATE,2,Robert Byrd,DEM,77
+Kanawha,222,U.S. SENATE,2,Robert Byrd,DEM,165
+Kanawha,223,U.S. SENATE,2,Robert Byrd,DEM,191
+Kanawha,224,U.S. SENATE,2,Robert Byrd,DEM,205
+Kanawha,226,U.S. SENATE,2,Robert Byrd,DEM,297
+Kanawha,227,U.S. SENATE,2,Robert Byrd,DEM,280
+Kanawha,228,U.S. SENATE,2,Robert Byrd,DEM,188
+Kanawha,232,U.S. SENATE,2,Robert Byrd,DEM,154
+Kanawha,233,U.S. SENATE,2,Robert Byrd,DEM,238
+Kanawha,234,U.S. SENATE,2,Robert Byrd,DEM,228
+Kanawha,235,U.S. SENATE,2,Robert Byrd,DEM,234
+Kanawha,238,U.S. SENATE,2,Robert Byrd,DEM,347
+Kanawha,239,U.S. SENATE,2,Robert Byrd,DEM,341
+Kanawha,240,U.S. SENATE,2,Robert Byrd,DEM,272
+Kanawha,241,U.S. SENATE,2,Robert Byrd,DEM,153
+Kanawha,244,U.S. SENATE,2,Robert Byrd,DEM,178
+Kanawha,245,U.S. SENATE,2,Robert Byrd,DEM,246
+Kanawha,246,U.S. SENATE,2,Robert Byrd,DEM,313
+Kanawha,247,U.S. SENATE,2,Robert Byrd,DEM,250
+Kanawha,250,U.S. SENATE,2,Robert Byrd,DEM,265
+Kanawha,252,U.S. SENATE,2,Robert Byrd,DEM,236
+Kanawha,253,U.S. SENATE,2,Robert Byrd,DEM,190
+Kanawha,254,U.S. SENATE,2,Robert Byrd,DEM,254
+Kanawha,257,U.S. SENATE,2,Robert Byrd,DEM,234
+Kanawha,258,U.S. SENATE,2,Robert Byrd,DEM,205
+Kanawha,259,U.S. SENATE,2,Robert Byrd,DEM,194
+Kanawha,260,U.S. SENATE,2,Robert Byrd,DEM,132
+Kanawha,263,U.S. SENATE,2,Robert Byrd,DEM,257
+Kanawha,264,U.S. SENATE,2,Robert Byrd,DEM,325
+Kanawha,265,U.S. SENATE,2,Robert Byrd,DEM,264
+Kanawha,266,U.S. SENATE,2,Robert Byrd,DEM,280
+Kanawha,269,U.S. SENATE,2,Robert Byrd,DEM,208
+Kanawha,270,U.S. SENATE,2,Robert Byrd,DEM,191
+Kanawha,271,U.S. SENATE,2,Robert Byrd,DEM,210
+Kanawha,272,U.S. SENATE,2,Robert Byrd,DEM,139
+Kanawha,275,U.S. SENATE,2,Robert Byrd,DEM,109
+Kanawha,276,U.S. SENATE,2,Robert Byrd,DEM,118
+Kanawha,277,U.S. SENATE,2,Robert Byrd,DEM,305
+Kanawha,301,U.S. SENATE,3,Robert Byrd,DEM,138
+Kanawha,302,U.S. SENATE,3,Robert Byrd,DEM,179
+Kanawha,304,U.S. SENATE,3,Robert Byrd,DEM,207
+Kanawha,305,U.S. SENATE,3,Robert Byrd,DEM,185
+Kanawha,306,U.S. SENATE,3,Robert Byrd,DEM,120
+Kanawha,307,U.S. SENATE,3,Robert Byrd,DEM,225
+Kanawha,308,U.S. SENATE,3,Robert Byrd,DEM,132
+Kanawha,309,U.S. SENATE,3,Robert Byrd,DEM,185
+Kanawha,310,U.S. SENATE,3,Robert Byrd,DEM,343
+Kanawha,311,U.S. SENATE,3,Robert Byrd,DEM,252
+Kanawha,312,U.S. SENATE,3,Robert Byrd,DEM,128
+Kanawha,313,U.S. SENATE,3,Robert Byrd,DEM,72
+Kanawha,314,U.S. SENATE,3,Robert Byrd,DEM,175
+Kanawha,317,U.S. SENATE,3,Robert Byrd,DEM,153
+Kanawha,318,U.S. SENATE,3,Robert Byrd,DEM,117
+Kanawha,321,U.S. SENATE,3,Robert Byrd,DEM,202
+Kanawha,322,U.S. SENATE,3,Robert Byrd,DEM,164
+Kanawha,325,U.S. SENATE,3,Robert Byrd,DEM,112
+Kanawha,326,U.S. SENATE,3,Robert Byrd,DEM,231
+Kanawha,329,U.S. SENATE,3,Robert Byrd,DEM,193
+Kanawha,330,U.S. SENATE,3,Robert Byrd,DEM,102
+Kanawha,332,U.S. SENATE,3,Robert Byrd,DEM,170
+Kanawha,333,U.S. SENATE,3,Robert Byrd,DEM,204
+Kanawha,336,U.S. SENATE,3,Robert Byrd,DEM,122
+Kanawha,337,U.S. SENATE,3,Robert Byrd,DEM,209
+Kanawha,340,U.S. SENATE,3,Robert Byrd,DEM,155
+Kanawha,341,U.S. SENATE,3,Robert Byrd,DEM,125
+Kanawha,344,U.S. SENATE,3,Robert Byrd,DEM,228
+Kanawha,345,U.S. SENATE,3,Robert Byrd,DEM,125
+Kanawha,347,U.S. SENATE,3,Robert Byrd,DEM,217
+Kanawha,348,U.S. SENATE,3,Robert Byrd,DEM,107
+Kanawha,350,U.S. SENATE,3,Robert Byrd,DEM,256
+Kanawha,352,U.S. SENATE,3,Robert Byrd,DEM,392
+Kanawha,353,U.S. SENATE,3,Robert Byrd,DEM,195
+Kanawha,355,U.S. SENATE,3,Robert Byrd,DEM,135
+Kanawha,356,U.S. SENATE,3,Robert Byrd,DEM,189
+Kanawha,357,U.S. SENATE,3,Robert Byrd,DEM,379
+Kanawha,360,U.S. SENATE,3,Robert Byrd,DEM,160
+Kanawha,361,U.S. SENATE,3,Robert Byrd,DEM,221
+Kanawha,375,U.S. SENATE,3,Robert Byrd,DEM,211
+Kanawha,376,U.S. SENATE,3,Robert Byrd,DEM,120
+Kanawha,378,U.S. SENATE,3,Robert Byrd,DEM,212
+Kanawha,379,U.S. SENATE,3,Robert Byrd,DEM,146
+Kanawha,401,U.S. SENATE,4,Robert Byrd,DEM,128
+Kanawha,402,U.S. SENATE,4,Robert Byrd,DEM,168
+Kanawha,403,U.S. SENATE,4,Robert Byrd,DEM,255
+Kanawha,406,U.S. SENATE,4,Robert Byrd,DEM,209
+Kanawha,408,U.S. SENATE,4,Robert Byrd,DEM,246
+Kanawha,409,U.S. SENATE,4,Robert Byrd,DEM,245
+Kanawha,411,U.S. SENATE,4,Robert Byrd,DEM,144
+Kanawha,412,U.S. SENATE,4,Robert Byrd,DEM,218
+Kanawha,414,U.S. SENATE,4,Robert Byrd,DEM,252
+Kanawha,435,U.S. SENATE,4,Robert Byrd,DEM,199
+Kanawha,436,U.S. SENATE,4,Robert Byrd,DEM,267
+Kanawha,437,U.S. SENATE,4,Robert Byrd,DEM,225
+Kanawha,438,U.S. SENATE,4,Robert Byrd,DEM,306
+Kanawha,439,U.S. SENATE,4,Robert Byrd,DEM,192
+Kanawha,440,U.S. SENATE,4,Robert Byrd,DEM,130
+Kanawha,441,U.S. SENATE,4,Robert Byrd,DEM,160
+Kanawha,442,U.S. SENATE,4,Robert Byrd,DEM,180
+Kanawha,444,U.S. SENATE,4,Robert Byrd,DEM,144
+Kanawha,446,U.S. SENATE,4,Robert Byrd,DEM,168
+Kanawha,447,U.S. SENATE,4,Robert Byrd,DEM,220
+Kanawha,448,U.S. SENATE,4,Robert Byrd,DEM,154
+Kanawha,449,U.S. SENATE,4,Robert Byrd,DEM,178
+Kanawha,450,U.S. SENATE,4,Robert Byrd,DEM,105
+Kanawha,453,U.S. SENATE,4,Robert Byrd,DEM,227
+Kanawha,454,U.S. SENATE,4,Robert Byrd,DEM,285
+Kanawha,455,U.S. SENATE,4,Robert Byrd,DEM,220
+Kanawha,459,U.S. SENATE,4,Robert Byrd,DEM,309
+Kanawha,462,U.S. SENATE,4,Robert Byrd,DEM,202
+Kanawha,463,U.S. SENATE,4,Robert Byrd,DEM,247
+Kanawha,464,U.S. SENATE,4,Robert Byrd,DEM,236
+Kanawha,465,U.S. SENATE,4,Robert Byrd,DEM,138
+Kanawha,466,U.S. SENATE,4,Robert Byrd,DEM,267
+Kanawha,468,U.S. SENATE,4,Robert Byrd,DEM,217
+Kanawha,469,U.S. SENATE,4,Robert Byrd,DEM,160
+Kanawha,501,U.S. SENATE,5,Robert Byrd,DEM,146
+Kanawha,502,U.S. SENATE,5,Robert Byrd,DEM,172
+Kanawha,503,U.S. SENATE,5,Robert Byrd,DEM,153
+Kanawha,504,U.S. SENATE,5,Robert Byrd,DEM,155
+Kanawha,508,U.S. SENATE,5,Robert Byrd,DEM,261
+Kanawha,509,U.S. SENATE,5,Robert Byrd,DEM,115
+Kanawha,510,U.S. SENATE,5,Robert Byrd,DEM,207
+Kanawha,513,U.S. SENATE,5,Robert Byrd,DEM,149
+Kanawha,514,U.S. SENATE,5,Robert Byrd,DEM,95
+Kanawha,515,U.S. SENATE,5,Robert Byrd,DEM,145
+Kanawha,518,U.S. SENATE,5,Robert Byrd,DEM,224
+Kanawha,520,U.S. SENATE,5,Robert Byrd,DEM,205
+Kanawha,522,U.S. SENATE,5,Robert Byrd,DEM,148
+Kanawha,526,U.S. SENATE,5,Robert Byrd,DEM,198
+Kanawha,527,U.S. SENATE,5,Robert Byrd,DEM,243
+Kanawha,528,U.S. SENATE,5,Robert Byrd,DEM,221
+Kanawha,529,U.S. SENATE,5,Robert Byrd,DEM,203
+Kanawha,532,U.S. SENATE,5,Robert Byrd,DEM,245
+Kanawha,533,U.S. SENATE,5,Robert Byrd,DEM,239
+Kanawha,535,U.S. SENATE,5,Robert Byrd,DEM,151
+Kanawha,540,U.S. SENATE,5,Robert Byrd,DEM,215
+Kanawha,541,U.S. SENATE,5,Robert Byrd,DEM,201
+Kanawha,542,U.S. SENATE,5,Robert Byrd,DEM,270
+Kanawha,546,U.S. SENATE,5,Robert Byrd,DEM,136
+Kanawha,547,U.S. SENATE,5,Robert Byrd,DEM,137
+Kanawha,549,U.S. SENATE,5,Robert Byrd,DEM,199
+Kanawha,550,U.S. SENATE,5,Robert Byrd,DEM,157
+Kanawha,553,U.S. SENATE,5,Robert Byrd,DEM,176
+Kanawha,554,U.S. SENATE,5,Robert Byrd,DEM,105
+Kanawha,556,U.S. SENATE,5,Robert Byrd,DEM,246
+Kanawha,560,U.S. SENATE,5,Robert Byrd,DEM,254
+Kanawha,561,U.S. SENATE,5,Robert Byrd,DEM,153
+Kanawha,562,U.S. SENATE,5,Robert Byrd,DEM,154
+Kanawha,565,U.S. SENATE,5,Robert Byrd,DEM,186
+Kanawha,566,U.S. SENATE,5,Robert Byrd,DEM,208
+Kanawha,567,U.S. SENATE,5,Robert Byrd,DEM,279
+Kanawha,568,U.S. SENATE,5,Robert Byrd,DEM,232
+Kanawha,571,U.S. SENATE,5,Robert Byrd,DEM,237
+Kanawha,572,U.S. SENATE,5,Robert Byrd,DEM,94
+Kanawha,573,U.S. SENATE,5,Robert Byrd,DEM,327
+Kanawha,574,U.S. SENATE,5,Robert Byrd,DEM,202
+Kanawha,601,U.S. SENATE,6,Robert Byrd,DEM,82
+Kanawha,602,U.S. SENATE,6,Robert Byrd,DEM,161
+Kanawha,603,U.S. SENATE,6,Robert Byrd,DEM,102
+Kanawha,606,U.S. SENATE,6,Robert Byrd,DEM,163
+Kanawha,607,U.S. SENATE,6,Robert Byrd,DEM,193
+Kanawha,608,U.S. SENATE,6,Robert Byrd,DEM,147
+Kanawha,611,U.S. SENATE,6,Robert Byrd,DEM,135
+Kanawha,612,U.S. SENATE,6,Robert Byrd,DEM,130
+Kanawha,614,U.S. SENATE,6,Robert Byrd,DEM,142
+Kanawha,616,U.S. SENATE,6,Robert Byrd,DEM,170
+Kanawha,617,U.S. SENATE,6,Robert Byrd,DEM,210
+Kanawha,620,U.S. SENATE,6,Robert Byrd,DEM,289
+Kanawha,621,U.S. SENATE,6,Robert Byrd,DEM,265
+Kanawha,624,U.S. SENATE,6,Robert Byrd,DEM,183
+Kanawha,625,U.S. SENATE,6,Robert Byrd,DEM,110
+Kanawha,626,U.S. SENATE,6,Robert Byrd,DEM,137
+Kanawha,628,U.S. SENATE,6,Robert Byrd,DEM,89
+Kanawha,629,U.S. SENATE,6,Robert Byrd,DEM,108
+Kanawha,630,U.S. SENATE,6,Robert Byrd,DEM,118
+Kanawha,632,U.S. SENATE,6,Robert Byrd,DEM,246
+Kanawha,633,U.S. SENATE,6,Robert Byrd,DEM,176
+Kanawha,634,U.S. SENATE,6,Robert Byrd,DEM,158
+Kanawha,636,U.S. SENATE,6,Robert Byrd,DEM,182
+Kanawha,638,U.S. SENATE,6,Robert Byrd,DEM,160
+Kanawha,641,U.S. SENATE,6,Robert Byrd,DEM,86
+Kanawha,642,U.S. SENATE,6,Robert Byrd,DEM,225
+Kanawha,644,U.S. SENATE,6,Robert Byrd,DEM,210
+Kanawha,645,U.S. SENATE,6,Robert Byrd,DEM,306
+Kanawha,648,U.S. SENATE,6,Robert Byrd,DEM,152
+Kanawha,649,U.S. SENATE,6,Robert Byrd,DEM,259
+Kanawha,650,U.S. SENATE,6,Robert Byrd,DEM,129
+Kanawha,652,U.S. SENATE,6,Robert Byrd,DEM,100
+Kanawha,653,U.S. SENATE,6,Robert Byrd,DEM,130
+Kanawha,656,U.S. SENATE,6,Robert Byrd,DEM,250
+Kanawha,Total,U.S. SENATE,,Robert Byrd,DEM,47520
+Kanawha,103,U.S. HOUSE,1,Paul Hart,REP,34
+Kanawha,104,U.S. HOUSE,1,Paul Hart,REP,14
+Kanawha,105,U.S. HOUSE,1,Paul Hart,REP,40
+Kanawha,106,U.S. HOUSE,1,Paul Hart,REP,22
+Kanawha,108,U.S. HOUSE,1,Paul Hart,REP,17
+Kanawha,109,U.S. HOUSE,1,Paul Hart,REP,34
+Kanawha,110,U.S. HOUSE,1,Paul Hart,REP,53
+Kanawha,111,U.S. HOUSE,1,Paul Hart,REP,44
+Kanawha,112,U.S. HOUSE,1,Paul Hart,REP,64
+Kanawha,113,U.S. HOUSE,1,Paul Hart,REP,64
+Kanawha,114,U.S. HOUSE,1,Paul Hart,REP,105
+Kanawha,115,U.S. HOUSE,1,Paul Hart,REP,51
+Kanawha,116,U.S. HOUSE,1,Paul Hart,REP,22
+Kanawha,117,U.S. HOUSE,1,Paul Hart,REP,70
+Kanawha,118,U.S. HOUSE,1,Paul Hart,REP,52
+Kanawha,119,U.S. HOUSE,1,Paul Hart,REP,80
+Kanawha,120,U.S. HOUSE,1,Paul Hart,REP,64
+Kanawha,122,U.S. HOUSE,1,Paul Hart,REP,27
+Kanawha,123,U.S. HOUSE,1,Paul Hart,REP,53
+Kanawha,131,U.S. HOUSE,1,Paul Hart,REP,30
+Kanawha,132,U.S. HOUSE,1,Paul Hart,REP,3
+Kanawha,133,U.S. HOUSE,1,Paul Hart,REP,15
+Kanawha,134,U.S. HOUSE,1,Paul Hart,REP,55
+Kanawha,136,U.S. HOUSE,1,Paul Hart,REP,32
+Kanawha,138,U.S. HOUSE,1,Paul Hart,REP,69
+Kanawha,140,U.S. HOUSE,1,Paul Hart,REP,7
+Kanawha,142,U.S. HOUSE,1,Paul Hart,REP,25
+Kanawha,145,U.S. HOUSE,1,Paul Hart,REP,27
+Kanawha,146,U.S. HOUSE,1,Paul Hart,REP,33
+Kanawha,147,U.S. HOUSE,1,Paul Hart,REP,50
+Kanawha,148,U.S. HOUSE,1,Paul Hart,REP,33
+Kanawha,149,U.S. HOUSE,1,Paul Hart,REP,40
+Kanawha,150,U.S. HOUSE,1,Paul Hart,REP,22
+Kanawha,151,U.S. HOUSE,1,Paul Hart,REP,15
+Kanawha,152,U.S. HOUSE,1,Paul Hart,REP,34
+Kanawha,153,U.S. HOUSE,1,Paul Hart,REP,62
+Kanawha,154,U.S. HOUSE,1,Paul Hart,REP,42
+Kanawha,158,U.S. HOUSE,1,Paul Hart,REP,29
+Kanawha,202,U.S. HOUSE,2,Paul Hart,REP,86
+Kanawha,205,U.S. HOUSE,2,Paul Hart,REP,129
+Kanawha,206,U.S. HOUSE,2,Paul Hart,REP,95
+Kanawha,207,U.S. HOUSE,2,Paul Hart,REP,103
+Kanawha,208,U.S. HOUSE,2,Paul Hart,REP,197
+Kanawha,209,U.S. HOUSE,2,Paul Hart,REP,81
+Kanawha,213,U.S. HOUSE,2,Paul Hart,REP,62
+Kanawha,217,U.S. HOUSE,2,Paul Hart,REP,82
+Kanawha,218,U.S. HOUSE,2,Paul Hart,REP,17
+Kanawha,222,U.S. HOUSE,2,Paul Hart,REP,74
+Kanawha,223,U.S. HOUSE,2,Paul Hart,REP,82
+Kanawha,224,U.S. HOUSE,2,Paul Hart,REP,100
+Kanawha,226,U.S. HOUSE,2,Paul Hart,REP,114
+Kanawha,227,U.S. HOUSE,2,Paul Hart,REP,124
+Kanawha,228,U.S. HOUSE,2,Paul Hart,REP,113
+Kanawha,232,U.S. HOUSE,2,Paul Hart,REP,45
+Kanawha,233,U.S. HOUSE,2,Paul Hart,REP,139
+Kanawha,234,U.S. HOUSE,2,Paul Hart,REP,118
+Kanawha,235,U.S. HOUSE,2,Paul Hart,REP,126
+Kanawha,238,U.S. HOUSE,2,Paul Hart,REP,140
+Kanawha,239,U.S. HOUSE,2,Paul Hart,REP,217
+Kanawha,240,U.S. HOUSE,2,Paul Hart,REP,144
+Kanawha,241,U.S. HOUSE,2,Paul Hart,REP,73
+Kanawha,244,U.S. HOUSE,2,Paul Hart,REP,99
+Kanawha,245,U.S. HOUSE,2,Paul Hart,REP,69
+Kanawha,246,U.S. HOUSE,2,Paul Hart,REP,152
+Kanawha,247,U.S. HOUSE,2,Paul Hart,REP,118
+Kanawha,250,U.S. HOUSE,2,Paul Hart,REP,129
+Kanawha,252,U.S. HOUSE,2,Paul Hart,REP,162
+Kanawha,253,U.S. HOUSE,2,Paul Hart,REP,120
+Kanawha,254,U.S. HOUSE,2,Paul Hart,REP,130
+Kanawha,257,U.S. HOUSE,2,Paul Hart,REP,112
+Kanawha,258,U.S. HOUSE,2,Paul Hart,REP,99
+Kanawha,259,U.S. HOUSE,2,Paul Hart,REP,53
+Kanawha,260,U.S. HOUSE,2,Paul Hart,REP,42
+Kanawha,263,U.S. HOUSE,2,Paul Hart,REP,153
+Kanawha,264,U.S. HOUSE,2,Paul Hart,REP,123
+Kanawha,265,U.S. HOUSE,2,Paul Hart,REP,133
+Kanawha,266,U.S. HOUSE,2,Paul Hart,REP,95
+Kanawha,269,U.S. HOUSE,2,Paul Hart,REP,104
+Kanawha,270,U.S. HOUSE,2,Paul Hart,REP,56
+Kanawha,271,U.S. HOUSE,2,Paul Hart,REP,51
+Kanawha,272,U.S. HOUSE,2,Paul Hart,REP,56
+Kanawha,275,U.S. HOUSE,2,Paul Hart,REP,42
+Kanawha,276,U.S. HOUSE,2,Paul Hart,REP,46
+Kanawha,277,U.S. HOUSE,2,Paul Hart,REP,200
+Kanawha,301,U.S. HOUSE,3,Paul Hart,REP,51
+Kanawha,302,U.S. HOUSE,3,Paul Hart,REP,65
+Kanawha,304,U.S. HOUSE,3,Paul Hart,REP,89
+Kanawha,305,U.S. HOUSE,3,Paul Hart,REP,62
+Kanawha,306,U.S. HOUSE,3,Paul Hart,REP,57
+Kanawha,307,U.S. HOUSE,3,Paul Hart,REP,132
+Kanawha,308,U.S. HOUSE,3,Paul Hart,REP,66
+Kanawha,309,U.S. HOUSE,3,Paul Hart,REP,90
+Kanawha,310,U.S. HOUSE,3,Paul Hart,REP,188
+Kanawha,311,U.S. HOUSE,3,Paul Hart,REP,133
+Kanawha,312,U.S. HOUSE,3,Paul Hart,REP,42
+Kanawha,313,U.S. HOUSE,3,Paul Hart,REP,26
+Kanawha,314,U.S. HOUSE,3,Paul Hart,REP,66
+Kanawha,317,U.S. HOUSE,3,Paul Hart,REP,60
+Kanawha,318,U.S. HOUSE,3,Paul Hart,REP,68
+Kanawha,321,U.S. HOUSE,3,Paul Hart,REP,100
+Kanawha,322,U.S. HOUSE,3,Paul Hart,REP,100
+Kanawha,325,U.S. HOUSE,3,Paul Hart,REP,53
+Kanawha,326,U.S. HOUSE,3,Paul Hart,REP,134
+Kanawha,329,U.S. HOUSE,3,Paul Hart,REP,88
+Kanawha,330,U.S. HOUSE,3,Paul Hart,REP,48
+Kanawha,332,U.S. HOUSE,3,Paul Hart,REP,67
+Kanawha,333,U.S. HOUSE,3,Paul Hart,REP,99
+Kanawha,336,U.S. HOUSE,3,Paul Hart,REP,61
+Kanawha,337,U.S. HOUSE,3,Paul Hart,REP,102
+Kanawha,340,U.S. HOUSE,3,Paul Hart,REP,76
+Kanawha,341,U.S. HOUSE,3,Paul Hart,REP,46
+Kanawha,344,U.S. HOUSE,3,Paul Hart,REP,113
+Kanawha,345,U.S. HOUSE,3,Paul Hart,REP,63
+Kanawha,347,U.S. HOUSE,3,Paul Hart,REP,139
+Kanawha,348,U.S. HOUSE,3,Paul Hart,REP,82
+Kanawha,350,U.S. HOUSE,3,Paul Hart,REP,128
+Kanawha,352,U.S. HOUSE,3,Paul Hart,REP,164
+Kanawha,353,U.S. HOUSE,3,Paul Hart,REP,74
+Kanawha,355,U.S. HOUSE,3,Paul Hart,REP,50
+Kanawha,356,U.S. HOUSE,3,Paul Hart,REP,55
+Kanawha,357,U.S. HOUSE,3,Paul Hart,REP,185
+Kanawha,360,U.S. HOUSE,3,Paul Hart,REP,55
+Kanawha,361,U.S. HOUSE,3,Paul Hart,REP,72
+Kanawha,375,U.S. HOUSE,3,Paul Hart,REP,114
+Kanawha,376,U.S. HOUSE,3,Paul Hart,REP,64
+Kanawha,378,U.S. HOUSE,3,Paul Hart,REP,116
+Kanawha,379,U.S. HOUSE,3,Paul Hart,REP,105
+Kanawha,401,U.S. HOUSE,4,Paul Hart,REP,109
+Kanawha,402,U.S. HOUSE,4,Paul Hart,REP,73
+Kanawha,403,U.S. HOUSE,4,Paul Hart,REP,89
+Kanawha,406,U.S. HOUSE,4,Paul Hart,REP,88
+Kanawha,408,U.S. HOUSE,4,Paul Hart,REP,104
+Kanawha,409,U.S. HOUSE,4,Paul Hart,REP,120
+Kanawha,411,U.S. HOUSE,4,Paul Hart,REP,62
+Kanawha,412,U.S. HOUSE,4,Paul Hart,REP,42
+Kanawha,414,U.S. HOUSE,4,Paul Hart,REP,25
+Kanawha,435,U.S. HOUSE,4,Paul Hart,REP,94
+Kanawha,436,U.S. HOUSE,4,Paul Hart,REP,151
+Kanawha,437,U.S. HOUSE,4,Paul Hart,REP,142
+Kanawha,438,U.S. HOUSE,4,Paul Hart,REP,199
+Kanawha,439,U.S. HOUSE,4,Paul Hart,REP,116
+Kanawha,440,U.S. HOUSE,4,Paul Hart,REP,88
+Kanawha,441,U.S. HOUSE,4,Paul Hart,REP,82
+Kanawha,442,U.S. HOUSE,4,Paul Hart,REP,119
+Kanawha,444,U.S. HOUSE,4,Paul Hart,REP,60
+Kanawha,446,U.S. HOUSE,4,Paul Hart,REP,104
+Kanawha,447,U.S. HOUSE,4,Paul Hart,REP,80
+Kanawha,448,U.S. HOUSE,4,Paul Hart,REP,77
+Kanawha,449,U.S. HOUSE,4,Paul Hart,REP,74
+Kanawha,450,U.S. HOUSE,4,Paul Hart,REP,60
+Kanawha,453,U.S. HOUSE,4,Paul Hart,REP,84
+Kanawha,454,U.S. HOUSE,4,Paul Hart,REP,77
+Kanawha,455,U.S. HOUSE,4,Paul Hart,REP,84
+Kanawha,459,U.S. HOUSE,4,Paul Hart,REP,115
+Kanawha,462,U.S. HOUSE,4,Paul Hart,REP,84
+Kanawha,463,U.S. HOUSE,4,Paul Hart,REP,122
+Kanawha,464,U.S. HOUSE,4,Paul Hart,REP,117
+Kanawha,465,U.S. HOUSE,4,Paul Hart,REP,61
+Kanawha,466,U.S. HOUSE,4,Paul Hart,REP,154
+Kanawha,468,U.S. HOUSE,4,Paul Hart,REP,189
+Kanawha,469,U.S. HOUSE,4,Paul Hart,REP,84
+Kanawha,501,U.S. HOUSE,5,Paul Hart,REP,53
+Kanawha,502,U.S. HOUSE,5,Paul Hart,REP,73
+Kanawha,503,U.S. HOUSE,5,Paul Hart,REP,56
+Kanawha,504,U.S. HOUSE,5,Paul Hart,REP,43
+Kanawha,508,U.S. HOUSE,5,Paul Hart,REP,124
+Kanawha,509,U.S. HOUSE,5,Paul Hart,REP,59
+Kanawha,510,U.S. HOUSE,5,Paul Hart,REP,91
+Kanawha,513,U.S. HOUSE,5,Paul Hart,REP,61
+Kanawha,514,U.S. HOUSE,5,Paul Hart,REP,16
+Kanawha,515,U.S. HOUSE,5,Paul Hart,REP,75
+Kanawha,518,U.S. HOUSE,5,Paul Hart,REP,82
+Kanawha,520,U.S. HOUSE,5,Paul Hart,REP,21
+Kanawha,522,U.S. HOUSE,5,Paul Hart,REP,26
+Kanawha,526,U.S. HOUSE,5,Paul Hart,REP,104
+Kanawha,527,U.S. HOUSE,5,Paul Hart,REP,126
+Kanawha,528,U.S. HOUSE,5,Paul Hart,REP,89
+Kanawha,529,U.S. HOUSE,5,Paul Hart,REP,101
+Kanawha,532,U.S. HOUSE,5,Paul Hart,REP,90
+Kanawha,533,U.S. HOUSE,5,Paul Hart,REP,103
+Kanawha,535,U.S. HOUSE,5,Paul Hart,REP,68
+Kanawha,540,U.S. HOUSE,5,Paul Hart,REP,81
+Kanawha,541,U.S. HOUSE,5,Paul Hart,REP,79
+Kanawha,542,U.S. HOUSE,5,Paul Hart,REP,121
+Kanawha,546,U.S. HOUSE,5,Paul Hart,REP,49
+Kanawha,547,U.S. HOUSE,5,Paul Hart,REP,84
+Kanawha,549,U.S. HOUSE,5,Paul Hart,REP,111
+Kanawha,550,U.S. HOUSE,5,Paul Hart,REP,58
+Kanawha,553,U.S. HOUSE,5,Paul Hart,REP,45
+Kanawha,554,U.S. HOUSE,5,Paul Hart,REP,29
+Kanawha,556,U.S. HOUSE,5,Paul Hart,REP,76
+Kanawha,560,U.S. HOUSE,5,Paul Hart,REP,64
+Kanawha,561,U.S. HOUSE,5,Paul Hart,REP,48
+Kanawha,562,U.S. HOUSE,5,Paul Hart,REP,32
+Kanawha,565,U.S. HOUSE,5,Paul Hart,REP,71
+Kanawha,566,U.S. HOUSE,5,Paul Hart,REP,60
+Kanawha,567,U.S. HOUSE,5,Paul Hart,REP,116
+Kanawha,568,U.S. HOUSE,5,Paul Hart,REP,59
+Kanawha,571,U.S. HOUSE,5,Paul Hart,REP,104
+Kanawha,572,U.S. HOUSE,5,Paul Hart,REP,24
+Kanawha,573,U.S. HOUSE,5,Paul Hart,REP,170
+Kanawha,574,U.S. HOUSE,5,Paul Hart,REP,68
+Kanawha,601,U.S. HOUSE,6,Paul Hart,REP,47
+Kanawha,602,U.S. HOUSE,6,Paul Hart,REP,62
+Kanawha,603,U.S. HOUSE,6,Paul Hart,REP,40
+Kanawha,606,U.S. HOUSE,6,Paul Hart,REP,110
+Kanawha,607,U.S. HOUSE,6,Paul Hart,REP,123
+Kanawha,608,U.S. HOUSE,6,Paul Hart,REP,56
+Kanawha,611,U.S. HOUSE,6,Paul Hart,REP,93
+Kanawha,612,U.S. HOUSE,6,Paul Hart,REP,105
+Kanawha,614,U.S. HOUSE,6,Paul Hart,REP,71
+Kanawha,616,U.S. HOUSE,6,Paul Hart,REP,85
+Kanawha,617,U.S. HOUSE,6,Paul Hart,REP,132
+Kanawha,620,U.S. HOUSE,6,Paul Hart,REP,125
+Kanawha,621,U.S. HOUSE,6,Paul Hart,REP,99
+Kanawha,624,U.S. HOUSE,6,Paul Hart,REP,107
+Kanawha,625,U.S. HOUSE,6,Paul Hart,REP,82
+Kanawha,626,U.S. HOUSE,6,Paul Hart,REP,79
+Kanawha,628,U.S. HOUSE,6,Paul Hart,REP,94
+Kanawha,629,U.S. HOUSE,6,Paul Hart,REP,115
+Kanawha,630,U.S. HOUSE,6,Paul Hart,REP,90
+Kanawha,632,U.S. HOUSE,6,Paul Hart,REP,211
+Kanawha,633,U.S. HOUSE,6,Paul Hart,REP,107
+Kanawha,634,U.S. HOUSE,6,Paul Hart,REP,110
+Kanawha,636,U.S. HOUSE,6,Paul Hart,REP,116
+Kanawha,638,U.S. HOUSE,6,Paul Hart,REP,157
+Kanawha,641,U.S. HOUSE,6,Paul Hart,REP,35
+Kanawha,642,U.S. HOUSE,6,Paul Hart,REP,120
+Kanawha,644,U.S. HOUSE,6,Paul Hart,REP,97
+Kanawha,645,U.S. HOUSE,6,Paul Hart,REP,171
+Kanawha,648,U.S. HOUSE,6,Paul Hart,REP,93
+Kanawha,649,U.S. HOUSE,6,Paul Hart,REP,146
+Kanawha,650,U.S. HOUSE,6,Paul Hart,REP,53
+Kanawha,652,U.S. HOUSE,6,Paul Hart,REP,37
+Kanawha,653,U.S. HOUSE,6,Paul Hart,REP,69
+Kanawha,656,U.S. HOUSE,6,Paul Hart,REP,116
+Kanawha,Total,U.S. HOUSE,,Paul Hart,REP,19778
+Kanawha,103,U.S. HOUSE,1,Bob Wise,DEM,353
+Kanawha,104,U.S. HOUSE,1,Bob Wise,DEM,191
+Kanawha,105,U.S. HOUSE,1,Bob Wise,DEM,297
+Kanawha,106,U.S. HOUSE,1,Bob Wise,DEM,280
+Kanawha,108,U.S. HOUSE,1,Bob Wise,DEM,268
+Kanawha,109,U.S. HOUSE,1,Bob Wise,DEM,179
+Kanawha,110,U.S. HOUSE,1,Bob Wise,DEM,215
+Kanawha,111,U.S. HOUSE,1,Bob Wise,DEM,193
+Kanawha,112,U.S. HOUSE,1,Bob Wise,DEM,262
+Kanawha,113,U.S. HOUSE,1,Bob Wise,DEM,230
+Kanawha,114,U.S. HOUSE,1,Bob Wise,DEM,421
+Kanawha,115,U.S. HOUSE,1,Bob Wise,DEM,363
+Kanawha,116,U.S. HOUSE,1,Bob Wise,DEM,196
+Kanawha,117,U.S. HOUSE,1,Bob Wise,DEM,389
+Kanawha,118,U.S. HOUSE,1,Bob Wise,DEM,277
+Kanawha,119,U.S. HOUSE,1,Bob Wise,DEM,265
+Kanawha,120,U.S. HOUSE,1,Bob Wise,DEM,288
+Kanawha,122,U.S. HOUSE,1,Bob Wise,DEM,166
+Kanawha,123,U.S. HOUSE,1,Bob Wise,DEM,188
+Kanawha,131,U.S. HOUSE,1,Bob Wise,DEM,245
+Kanawha,132,U.S. HOUSE,1,Bob Wise,DEM,63
+Kanawha,133,U.S. HOUSE,1,Bob Wise,DEM,142
+Kanawha,134,U.S. HOUSE,1,Bob Wise,DEM,267
+Kanawha,136,U.S. HOUSE,1,Bob Wise,DEM,431
+Kanawha,138,U.S. HOUSE,1,Bob Wise,DEM,355
+Kanawha,140,U.S. HOUSE,1,Bob Wise,DEM,292
+Kanawha,142,U.S. HOUSE,1,Bob Wise,DEM,321
+Kanawha,145,U.S. HOUSE,1,Bob Wise,DEM,280
+Kanawha,146,U.S. HOUSE,1,Bob Wise,DEM,181
+Kanawha,147,U.S. HOUSE,1,Bob Wise,DEM,220
+Kanawha,148,U.S. HOUSE,1,Bob Wise,DEM,202
+Kanawha,149,U.S. HOUSE,1,Bob Wise,DEM,263
+Kanawha,150,U.S. HOUSE,1,Bob Wise,DEM,181
+Kanawha,151,U.S. HOUSE,1,Bob Wise,DEM,162
+Kanawha,152,U.S. HOUSE,1,Bob Wise,DEM,199
+Kanawha,153,U.S. HOUSE,1,Bob Wise,DEM,239
+Kanawha,154,U.S. HOUSE,1,Bob Wise,DEM,232
+Kanawha,158,U.S. HOUSE,1,Bob Wise,DEM,219
+Kanawha,202,U.S. HOUSE,2,Bob Wise,DEM,202
+Kanawha,205,U.S. HOUSE,2,Bob Wise,DEM,356
+Kanawha,206,U.S. HOUSE,2,Bob Wise,DEM,172
+Kanawha,207,U.S. HOUSE,2,Bob Wise,DEM,220
+Kanawha,208,U.S. HOUSE,2,Bob Wise,DEM,407
+Kanawha,209,U.S. HOUSE,2,Bob Wise,DEM,226
+Kanawha,213,U.S. HOUSE,2,Bob Wise,DEM,170
+Kanawha,217,U.S. HOUSE,2,Bob Wise,DEM,192
+Kanawha,218,U.S. HOUSE,2,Bob Wise,DEM,88
+Kanawha,222,U.S. HOUSE,2,Bob Wise,DEM,190
+Kanawha,223,U.S. HOUSE,2,Bob Wise,DEM,215
+Kanawha,224,U.S. HOUSE,2,Bob Wise,DEM,231
+Kanawha,226,U.S. HOUSE,2,Bob Wise,DEM,343
+Kanawha,227,U.S. HOUSE,2,Bob Wise,DEM,312
+Kanawha,228,U.S. HOUSE,2,Bob Wise,DEM,214
+Kanawha,232,U.S. HOUSE,2,Bob Wise,DEM,168
+Kanawha,233,U.S. HOUSE,2,Bob Wise,DEM,285
+Kanawha,234,U.S. HOUSE,2,Bob Wise,DEM,255
+Kanawha,235,U.S. HOUSE,2,Bob Wise,DEM,274
+Kanawha,238,U.S. HOUSE,2,Bob Wise,DEM,387
+Kanawha,239,U.S. HOUSE,2,Bob Wise,DEM,399
+Kanawha,240,U.S. HOUSE,2,Bob Wise,DEM,310
+Kanawha,241,U.S. HOUSE,2,Bob Wise,DEM,169
+Kanawha,244,U.S. HOUSE,2,Bob Wise,DEM,183
+Kanawha,245,U.S. HOUSE,2,Bob Wise,DEM,265
+Kanawha,246,U.S. HOUSE,2,Bob Wise,DEM,359
+Kanawha,247,U.S. HOUSE,2,Bob Wise,DEM,268
+Kanawha,250,U.S. HOUSE,2,Bob Wise,DEM,307
+Kanawha,252,U.S. HOUSE,2,Bob Wise,DEM,276
+Kanawha,253,U.S. HOUSE,2,Bob Wise,DEM,208
+Kanawha,254,U.S. HOUSE,2,Bob Wise,DEM,331
+Kanawha,257,U.S. HOUSE,2,Bob Wise,DEM,251
+Kanawha,258,U.S. HOUSE,2,Bob Wise,DEM,217
+Kanawha,259,U.S. HOUSE,2,Bob Wise,DEM,207
+Kanawha,260,U.S. HOUSE,2,Bob Wise,DEM,152
+Kanawha,263,U.S. HOUSE,2,Bob Wise,DEM,278
+Kanawha,264,U.S. HOUSE,2,Bob Wise,DEM,371
+Kanawha,265,U.S. HOUSE,2,Bob Wise,DEM,296
+Kanawha,266,U.S. HOUSE,2,Bob Wise,DEM,313
+Kanawha,269,U.S. HOUSE,2,Bob Wise,DEM,221
+Kanawha,270,U.S. HOUSE,2,Bob Wise,DEM,212
+Kanawha,271,U.S. HOUSE,2,Bob Wise,DEM,222
+Kanawha,272,U.S. HOUSE,2,Bob Wise,DEM,160
+Kanawha,275,U.S. HOUSE,2,Bob Wise,DEM,97
+Kanawha,276,U.S. HOUSE,2,Bob Wise,DEM,146
+Kanawha,277,U.S. HOUSE,2,Bob Wise,DEM,358
+Kanawha,301,U.S. HOUSE,3,Bob Wise,DEM,164
+Kanawha,302,U.S. HOUSE,3,Bob Wise,DEM,211
+Kanawha,304,U.S. HOUSE,3,Bob Wise,DEM,235
+Kanawha,305,U.S. HOUSE,3,Bob Wise,DEM,204
+Kanawha,306,U.S. HOUSE,3,Bob Wise,DEM,130
+Kanawha,307,U.S. HOUSE,3,Bob Wise,DEM,292
+Kanawha,308,U.S. HOUSE,3,Bob Wise,DEM,151
+Kanawha,309,U.S. HOUSE,3,Bob Wise,DEM,251
+Kanawha,310,U.S. HOUSE,3,Bob Wise,DEM,422
+Kanawha,311,U.S. HOUSE,3,Bob Wise,DEM,303
+Kanawha,312,U.S. HOUSE,3,Bob Wise,DEM,142
+Kanawha,313,U.S. HOUSE,3,Bob Wise,DEM,81
+Kanawha,314,U.S. HOUSE,3,Bob Wise,DEM,206
+Kanawha,317,U.S. HOUSE,3,Bob Wise,DEM,160
+Kanawha,318,U.S. HOUSE,3,Bob Wise,DEM,142
+Kanawha,321,U.S. HOUSE,3,Bob Wise,DEM,243
+Kanawha,322,U.S. HOUSE,3,Bob Wise,DEM,202
+Kanawha,325,U.S. HOUSE,3,Bob Wise,DEM,137
+Kanawha,326,U.S. HOUSE,3,Bob Wise,DEM,290
+Kanawha,329,U.S. HOUSE,3,Bob Wise,DEM,240
+Kanawha,330,U.S. HOUSE,3,Bob Wise,DEM,118
+Kanawha,332,U.S. HOUSE,3,Bob Wise,DEM,223
+Kanawha,333,U.S. HOUSE,3,Bob Wise,DEM,243
+Kanawha,336,U.S. HOUSE,3,Bob Wise,DEM,142
+Kanawha,337,U.S. HOUSE,3,Bob Wise,DEM,243
+Kanawha,340,U.S. HOUSE,3,Bob Wise,DEM,206
+Kanawha,341,U.S. HOUSE,3,Bob Wise,DEM,152
+Kanawha,344,U.S. HOUSE,3,Bob Wise,DEM,278
+Kanawha,345,U.S. HOUSE,3,Bob Wise,DEM,155
+Kanawha,347,U.S. HOUSE,3,Bob Wise,DEM,252
+Kanawha,348,U.S. HOUSE,3,Bob Wise,DEM,121
+Kanawha,350,U.S. HOUSE,3,Bob Wise,DEM,285
+Kanawha,352,U.S. HOUSE,3,Bob Wise,DEM,470
+Kanawha,353,U.S. HOUSE,3,Bob Wise,DEM,249
+Kanawha,355,U.S. HOUSE,3,Bob Wise,DEM,153
+Kanawha,356,U.S. HOUSE,3,Bob Wise,DEM,202
+Kanawha,357,U.S. HOUSE,3,Bob Wise,DEM,426
+Kanawha,360,U.S. HOUSE,3,Bob Wise,DEM,186
+Kanawha,361,U.S. HOUSE,3,Bob Wise,DEM,238
+Kanawha,375,U.S. HOUSE,3,Bob Wise,DEM,249
+Kanawha,376,U.S. HOUSE,3,Bob Wise,DEM,143
+Kanawha,378,U.S. HOUSE,3,Bob Wise,DEM,245
+Kanawha,379,U.S. HOUSE,3,Bob Wise,DEM,180
+Kanawha,401,U.S. HOUSE,4,Bob Wise,DEM,159
+Kanawha,402,U.S. HOUSE,4,Bob Wise,DEM,202
+Kanawha,403,U.S. HOUSE,4,Bob Wise,DEM,276
+Kanawha,406,U.S. HOUSE,4,Bob Wise,DEM,231
+Kanawha,408,U.S. HOUSE,4,Bob Wise,DEM,274
+Kanawha,409,U.S. HOUSE,4,Bob Wise,DEM,295
+Kanawha,411,U.S. HOUSE,4,Bob Wise,DEM,163
+Kanawha,412,U.S. HOUSE,4,Bob Wise,DEM,237
+Kanawha,414,U.S. HOUSE,4,Bob Wise,DEM,281
+Kanawha,435,U.S. HOUSE,4,Bob Wise,DEM,222
+Kanawha,436,U.S. HOUSE,4,Bob Wise,DEM,330
+Kanawha,437,U.S. HOUSE,4,Bob Wise,DEM,294
+Kanawha,438,U.S. HOUSE,4,Bob Wise,DEM,375
+Kanawha,439,U.S. HOUSE,4,Bob Wise,DEM,226
+Kanawha,440,U.S. HOUSE,4,Bob Wise,DEM,152
+Kanawha,441,U.S. HOUSE,4,Bob Wise,DEM,185
+Kanawha,442,U.S. HOUSE,4,Bob Wise,DEM,227
+Kanawha,444,U.S. HOUSE,4,Bob Wise,DEM,168
+Kanawha,446,U.S. HOUSE,4,Bob Wise,DEM,209
+Kanawha,447,U.S. HOUSE,4,Bob Wise,DEM,261
+Kanawha,448,U.S. HOUSE,4,Bob Wise,DEM,182
+Kanawha,449,U.S. HOUSE,4,Bob Wise,DEM,199
+Kanawha,450,U.S. HOUSE,4,Bob Wise,DEM,135
+Kanawha,453,U.S. HOUSE,4,Bob Wise,DEM,263
+Kanawha,454,U.S. HOUSE,4,Bob Wise,DEM,330
+Kanawha,455,U.S. HOUSE,4,Bob Wise,DEM,243
+Kanawha,459,U.S. HOUSE,4,Bob Wise,DEM,343
+Kanawha,462,U.S. HOUSE,4,Bob Wise,DEM,220
+Kanawha,463,U.S. HOUSE,4,Bob Wise,DEM,294
+Kanawha,464,U.S. HOUSE,4,Bob Wise,DEM,296
+Kanawha,465,U.S. HOUSE,4,Bob Wise,DEM,155
+Kanawha,466,U.S. HOUSE,4,Bob Wise,DEM,314
+Kanawha,468,U.S. HOUSE,4,Bob Wise,DEM,277
+Kanawha,469,U.S. HOUSE,4,Bob Wise,DEM,172
+Kanawha,501,U.S. HOUSE,5,Bob Wise,DEM,174
+Kanawha,502,U.S. HOUSE,5,Bob Wise,DEM,202
+Kanawha,503,U.S. HOUSE,5,Bob Wise,DEM,165
+Kanawha,504,U.S. HOUSE,5,Bob Wise,DEM,160
+Kanawha,508,U.S. HOUSE,5,Bob Wise,DEM,285
+Kanawha,509,U.S. HOUSE,5,Bob Wise,DEM,118
+Kanawha,510,U.S. HOUSE,5,Bob Wise,DEM,236
+Kanawha,513,U.S. HOUSE,5,Bob Wise,DEM,163
+Kanawha,514,U.S. HOUSE,5,Bob Wise,DEM,98
+Kanawha,515,U.S. HOUSE,5,Bob Wise,DEM,161
+Kanawha,518,U.S. HOUSE,5,Bob Wise,DEM,246
+Kanawha,520,U.S. HOUSE,5,Bob Wise,DEM,200
+Kanawha,522,U.S. HOUSE,5,Bob Wise,DEM,145
+Kanawha,526,U.S. HOUSE,5,Bob Wise,DEM,233
+Kanawha,527,U.S. HOUSE,5,Bob Wise,DEM,284
+Kanawha,528,U.S. HOUSE,5,Bob Wise,DEM,247
+Kanawha,529,U.S. HOUSE,5,Bob Wise,DEM,245
+Kanawha,532,U.S. HOUSE,5,Bob Wise,DEM,256
+Kanawha,533,U.S. HOUSE,5,Bob Wise,DEM,284
+Kanawha,535,U.S. HOUSE,5,Bob Wise,DEM,178
+Kanawha,540,U.S. HOUSE,5,Bob Wise,DEM,243
+Kanawha,541,U.S. HOUSE,5,Bob Wise,DEM,254
+Kanawha,542,U.S. HOUSE,5,Bob Wise,DEM,307
+Kanawha,546,U.S. HOUSE,5,Bob Wise,DEM,154
+Kanawha,547,U.S. HOUSE,5,Bob Wise,DEM,200
+Kanawha,549,U.S. HOUSE,5,Bob Wise,DEM,234
+Kanawha,550,U.S. HOUSE,5,Bob Wise,DEM,159
+Kanawha,553,U.S. HOUSE,5,Bob Wise,DEM,192
+Kanawha,554,U.S. HOUSE,5,Bob Wise,DEM,100
+Kanawha,556,U.S. HOUSE,5,Bob Wise,DEM,275
+Kanawha,560,U.S. HOUSE,5,Bob Wise,DEM,280
+Kanawha,561,U.S. HOUSE,5,Bob Wise,DEM,165
+Kanawha,562,U.S. HOUSE,5,Bob Wise,DEM,165
+Kanawha,565,U.S. HOUSE,5,Bob Wise,DEM,197
+Kanawha,566,U.S. HOUSE,5,Bob Wise,DEM,215
+Kanawha,567,U.S. HOUSE,5,Bob Wise,DEM,286
+Kanawha,568,U.S. HOUSE,5,Bob Wise,DEM,243
+Kanawha,571,U.S. HOUSE,5,Bob Wise,DEM,273
+Kanawha,572,U.S. HOUSE,5,Bob Wise,DEM,101
+Kanawha,573,U.S. HOUSE,5,Bob Wise,DEM,417
+Kanawha,574,U.S. HOUSE,5,Bob Wise,DEM,210
+Kanawha,601,U.S. HOUSE,6,Bob Wise,DEM,96
+Kanawha,602,U.S. HOUSE,6,Bob Wise,DEM,205
+Kanawha,603,U.S. HOUSE,6,Bob Wise,DEM,134
+Kanawha,606,U.S. HOUSE,6,Bob Wise,DEM,196
+Kanawha,607,U.S. HOUSE,6,Bob Wise,DEM,241
+Kanawha,608,U.S. HOUSE,6,Bob Wise,DEM,192
+Kanawha,611,U.S. HOUSE,6,Bob Wise,DEM,185
+Kanawha,612,U.S. HOUSE,6,Bob Wise,DEM,162
+Kanawha,614,U.S. HOUSE,6,Bob Wise,DEM,159
+Kanawha,616,U.S. HOUSE,6,Bob Wise,DEM,201
+Kanawha,617,U.S. HOUSE,6,Bob Wise,DEM,259
+Kanawha,620,U.S. HOUSE,6,Bob Wise,DEM,351
+Kanawha,621,U.S. HOUSE,6,Bob Wise,DEM,323
+Kanawha,624,U.S. HOUSE,6,Bob Wise,DEM,200
+Kanawha,625,U.S. HOUSE,6,Bob Wise,DEM,127
+Kanawha,626,U.S. HOUSE,6,Bob Wise,DEM,153
+Kanawha,628,U.S. HOUSE,6,Bob Wise,DEM,97
+Kanawha,629,U.S. HOUSE,6,Bob Wise,DEM,119
+Kanawha,630,U.S. HOUSE,6,Bob Wise,DEM,166
+Kanawha,632,U.S. HOUSE,6,Bob Wise,DEM,309
+Kanawha,633,U.S. HOUSE,6,Bob Wise,DEM,249
+Kanawha,634,U.S. HOUSE,6,Bob Wise,DEM,220
+Kanawha,636,U.S. HOUSE,6,Bob Wise,DEM,210
+Kanawha,638,U.S. HOUSE,6,Bob Wise,DEM,192
+Kanawha,641,U.S. HOUSE,6,Bob Wise,DEM,113
+Kanawha,642,U.S. HOUSE,6,Bob Wise,DEM,267
+Kanawha,644,U.S. HOUSE,6,Bob Wise,DEM,260
+Kanawha,645,U.S. HOUSE,6,Bob Wise,DEM,416
+Kanawha,648,U.S. HOUSE,6,Bob Wise,DEM,228
+Kanawha,649,U.S. HOUSE,6,Bob Wise,DEM,342
+Kanawha,650,U.S. HOUSE,6,Bob Wise,DEM,170
+Kanawha,652,U.S. HOUSE,6,Bob Wise,DEM,114
+Kanawha,653,U.S. HOUSE,6,Bob Wise,DEM,162
+Kanawha,656,U.S. HOUSE,6,Bob Wise,DEM,312
+Kanawha,Total,U.S. HOUSE,,Bob Wise,DEM,54433


### PR DESCRIPTION
This is the data for President, U.S. Senate, and U.S. House. There is a minor issue.

The sums calculated from the precincts (using spreadsheet functions) do not match those in the document (at openelections-sources-wv/1988) in both of the U.S. House elections. All other elections match ok. I have included the calculated sums instead of the ones listed in the document. I hope I only made a mistake somewhere inputting numbers, but I've checked it many times and I have found no errors. 

I'm not sure if there is a policy either way, but my guess would be that I did the correct thing. If there is a way to notate a difference from the source file, please let me know for future reference.