### PR TITLE
Update format tests

### DIFF
--- a/.github/workflows/format_tests.yml
+++ b/.github/workflows/format_tests.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         repository: openelections/openelections-format-tests
-        ref: v0.1.0
+        ref: v1.0.0
         path: format_tests
 
     - name: Run format tests


### PR DESCRIPTION
This updates the format tests to version [1.0.0](https://github.com/openelections/openelections-format-tests/releases/tag). The tests now verify that the "votes" column contains values that represent integers.  This reveals the following errors:

* 2008/20081104__wv__general__boone__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes']:
	Row 403: ['Boone', '32', 'U.S. HOUSE', '3', 'MARTY GEARHEART', 'REPUBLICAN', '4.6']
  ```

* 2008/20081104__wv__general__mercer__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 1377: ['Mercer', '64', 'Attorney General', '', 'Democratic', 'Darrell McGraw', '0.112']
  ```

* 2008/20081104__wv__general__kanawha__precinct.csv
  ```
  * There are 1 rows with votes that aren't integers:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes']:
	Row 4593: ['Kanawha', '110', 'MEMBER OF HOUSE OF DELEGATES', '30', 'TODD CARDEN', 'REPUBLICAN', '11.1']
  ```

These will be fixed in a subsequent pull request.
